### PR TITLE
Phony targets. Fix crash. Ignore dollar.

### DIFF
--- a/package.json
+++ b/package.json
@@ -390,8 +390,14 @@
                     "description": "Always run the pre-configure script before configure",
                     "default": false,
                     "scope": "resource"
-                }
-            }
+                },
+                "makefile.phonyOnlyTargets": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Display only the phony targets",
+                  "scope": "resource"
+              }
+          }
         },
         "viewsContainers": {
             "activitybar": [

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -677,6 +677,16 @@ export function readConfigureAfterCommand(): void {
     logger.message(`Configure after command: ${configureAfterCommand}`);
 }
 
+let phonyOnlyTargets: boolean | undefined;
+export function getPhonyOnlyTargets(): boolean | undefined { return phonyOnlyTargets; }
+export function setPhonyOnlyTargets(configure: boolean): void { phonyOnlyTargets = configure; }
+export function readPhonyOnlyTargets(): void {
+    let workspaceConfiguration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("makefile");
+    // how to get default from package.json to avoid problem with 'undefined' type?
+    phonyOnlyTargets = workspaceConfiguration.get<boolean>("phonyOnlyTargets");
+    logger.message(`Only .PHONY targets: ${phonyOnlyTargets}`);
+}
+
 // Initialization from settings (or backup default rules), done at activation time
 export async function initFromStateAndSettings(): Promise<void> {
     readConfigurationCachePath();
@@ -694,6 +704,7 @@ export async function initFromStateAndSettings(): Promise<void> {
     readConfigureOnOpen();
     readConfigureOnEdit();
     readConfigureAfterCommand();
+    readPhonyOnlyTargets();
 
     analyzeConfigureParams();
 
@@ -961,6 +972,13 @@ export async function initFromStateAndSettings(): Promise<void> {
             let updatedConfigureAfterCommand : boolean | undefined = workspaceConfiguration.get<boolean>(subKey);
             if (updatedConfigureAfterCommand !== configureAfterCommand) {
                 readConfigureAfterCommand();
+                updatedSettingsSubkeys.push(subKey);
+            }
+
+            subKey = "phonyOnlyTargets";
+            let updatedPhonyOnlyTargets : boolean | undefined = workspaceConfiguration.get<boolean>(subKey);
+            if (updatedPhonyOnlyTargets !== phonyOnlyTargets) {
+                readPhonyOnlyTargets();
                 updatedSettingsSubkeys.push(subKey);
             }
 

--- a/src/make.ts
+++ b/src/make.ts
@@ -559,12 +559,15 @@ export async function preConfigure(triggeredBy: TriggeredBy): Promise<number> {
 // The input 'content' represents the output of a command that lists all the environment variables:
 // set on windows or printenv on linux/mac.
 async function applyEnvironment(content: string | undefined) : Promise<void> {
-    let lines: string[] = content?.split(/\r?\n/) || [];
-    lines.forEach(line => {
-        let eqPos: number = line.search("=");
-        let envVarName: string = line.substring(0, eqPos);
-        let envVarValue: string = line.substring(eqPos + 1, line.length);
-        process.env[envVarName] = envVarValue;
+   let lines: string[] = content?.split(/\r?\n/) || [];
+   lines.forEach(line => {
+      let eqPos: number = line.search("=");
+      // Sometimes we get a "" line and searching for = returns -1. Skip.
+      if (eqPos !== -1) {
+          let envVarName: string = line.substring(0, eqPos);
+          let envVarValue: string = line.substring(eqPos + 1, line.length);
+          process.env[envVarName] = envVarValue;
+       }
     });
 }
 


### PR DESCRIPTION
Add ability to list only the makefile targets marked as .PHONY by the developer.

Fix crash when running preconfigure script.

Don't parse lines that contain dollar. Remove them during the preprocess phase.
