### PR TITLE
Add build and launch commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -417,12 +417,30 @@
                     "scope": "resource"
                 },
                 "makefile.phonyOnlyTargets": {
-                  "type": "boolean",
-                  "default": false,
-                  "description": "Display only the phony targets",
-                  "scope": "resource"
-              }
-          }
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Display only the phony targets",
+                    "scope": "resource"
+                },
+                "makefile.saveBeforeBuildOrConfigure": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Save opened files before building or configuring",
+                    "scope": "resource"
+                },
+                "makefile.buildBeforeLaunch": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Build the current target before launch (debug/run)",
+                    "scope": "resource"
+                },
+                "makefile.clearOutputBeforeBuild": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Clear the output channel at the beginning of a build",
+                    "scope": "resource"
+                }
+            }
         },
         "viewsContainers": {
             "activitybar": [

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -724,7 +724,7 @@ export function setSaveBeforeBuildOrConfigure(save: boolean): void { saveBeforeB
 export function readSaveBeforeBuildOrConfigure(): void {
     let workspaceConfiguration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("makefile");
     saveBeforeBuildOrConfigure = workspaceConfiguration.get<boolean>("saveBeforeBuildOrConfigure");
-    logger.message(`Save before build: ${saveBeforeBuildOrConfigure}`);
+    logger.message(`Save before build or configure: ${saveBeforeBuildOrConfigure}`);
 }
 
 let buildBeforeLaunch: boolean | undefined;

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -718,6 +718,33 @@ export function readPhonyOnlyTargets(): void {
     logger.message(`Only .PHONY targets: ${phonyOnlyTargets}`);
 }
 
+let saveBeforeBuildOrConfigure: boolean | undefined;
+export function getSaveBeforeBuildOrConfigure(): boolean | undefined { return saveBeforeBuildOrConfigure; }
+export function setSaveBeforeBuildOrConfigure(save: boolean): void { saveBeforeBuildOrConfigure = save; }
+export function readSaveBeforeBuildOrConfigure(): void {
+    let workspaceConfiguration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("makefile");
+    saveBeforeBuildOrConfigure = workspaceConfiguration.get<boolean>("saveBeforeBuildOrConfigure");
+    logger.message(`Save before build: ${saveBeforeBuildOrConfigure}`);
+}
+
+let buildBeforeLaunch: boolean | undefined;
+export function getBuildBeforeLaunch(): boolean | undefined { return buildBeforeLaunch; }
+export function setBuildBeforeLaunch(build: boolean): void { buildBeforeLaunch = build; }
+export function readBuildBeforeLaunch(): void {
+    let workspaceConfiguration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("makefile");
+    buildBeforeLaunch = workspaceConfiguration.get<boolean>("buildBeforeLaunch");
+    logger.message(`Build before launch: ${buildBeforeLaunch}`);
+}
+
+let clearOutputBeforeBuild: boolean | undefined;
+export function getClearOutputBeforeBuild(): boolean | undefined { return clearOutputBeforeBuild; }
+export function setClearOutputBeforeBuild(clear: boolean): void { clearOutputBeforeBuild = clear; }
+export function readClearOutputBeforeBuild(): void {
+    let workspaceConfiguration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("makefile");
+    clearOutputBeforeBuild = workspaceConfiguration.get<boolean>("clearOutputBeforeBuild");
+    logger.message(`Clear output before build: ${clearOutputBeforeBuild}`);
+}
+
 // This setting is useful for some repos where directory changing commands (cd, push, pop)
 // are missing or printed more than once, resulting in associating some IntelliSense information
 // with the wrong file or even with a non existent URL.
@@ -754,6 +781,9 @@ export async function initFromStateAndSettings(): Promise<void> {
     readConfigureOnEdit();
     readConfigureAfterCommand();
     readPhonyOnlyTargets();
+    readSaveBeforeBuildOrConfigure();
+    readBuildBeforeLaunch();
+    readClearOutputBeforeBuild();
     readIgnoreDirectoryCommands();
 
     analyzeConfigureParams();
@@ -1049,6 +1079,27 @@ export async function initFromStateAndSettings(): Promise<void> {
             let updatedPhonyOnlyTargets : boolean | undefined = workspaceConfiguration.get<boolean>(subKey);
             if (updatedPhonyOnlyTargets !== phonyOnlyTargets) {
                 readPhonyOnlyTargets();
+                updatedSettingsSubkeys.push(subKey);
+            }
+
+            subKey = "saveBeforeBuildOrConfigure";
+            let updatedSaveBeforeBuildOrConfigure : boolean | undefined = workspaceConfiguration.get<boolean>(subKey);
+            if (updatedSaveBeforeBuildOrConfigure !== saveBeforeBuildOrConfigure) {
+                readSaveBeforeBuildOrConfigure();
+                updatedSettingsSubkeys.push(subKey);
+            }
+
+            subKey = "buildBeforeLaunch";
+            let updatedBuildBeforeLaunch : boolean | undefined = workspaceConfiguration.get<boolean>(subKey);
+            if (updatedBuildBeforeLaunch !== buildBeforeLaunch) {
+                readBuildBeforeLaunch();
+                updatedSettingsSubkeys.push(subKey);
+            }
+
+            subKey = "clearOutputBeforeBuild";
+            let updatedClearOutputBeforeBuild : boolean | undefined = workspaceConfiguration.get<boolean>(subKey);
+            if (updatedClearOutputBeforeBuild !== clearOutputBeforeBuild) {
+                readClearOutputBeforeBuild();
                 updatedSettingsSubkeys.push(subKey);
             }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -235,9 +235,19 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     context.subscriptions.push(vscode.commands.registerCommand('makefile.launchTargetFileName', () => {
       telemetry.logEvent("launchTargetFileName");
       return launcher.launchTargetFileName();
-  }));
+    }));
 
-  context.subscriptions.push(vscode.commands.registerCommand('makefile.launchTargetArgs', () => {
+    context.subscriptions.push(vscode.commands.registerCommand('makefile.buildAndLaunchTargetPath', () => {
+      telemetry.logEvent("buildAndLaunchTargetPath");
+      return launcher.buildAndLaunchTargetPath();
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand('makefile.buildAndLaunchTargetFileName', () => {
+      telemetry.logEvent("buildAndLaunchTargetFileName");
+      return launcher.buildAndLaunchTargetFileName();
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand('makefile.launchTargetArgs', () => {
         telemetry.logEvent("launchTargetArgs");
         return launcher.launchTargetArgs();
     }));

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -193,9 +193,10 @@ export class Launcher implements vscode.Disposable {
             if (!buildSuccess) {
                 logger.message(`Building target "${currentBuildTarget}" failed.`);
                 let noButton: string = "No";
+                let yesButton: string = "Yes";
                 const chosen: vscode.MessageItem | undefined = await vscode.window.showErrorMessage<vscode.MessageItem>("Build failed. Do you want to continue anyway?",
                 {
-                    title: "Yes",
+                    title: yesButton,
                     isCloseAffordance: false,
                 },
                 {

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -52,11 +52,32 @@ export class Launcher implements vscode.Disposable {
       if (launchConfiguration) {
           return path.parse(launchConfiguration.binaryPath).name;
       } else {
-          return vscode.workspace.rootPath || "";
+          return "";
       }
-  }
+    }
 
-  // Command property accessible from launch.json:
+    // Command property accessible from launch.json:
+    // the file name of the current target binary, without path or extension,
+    // after triggering a build of the current target.
+    public async buildAndLaunchTargetFileName(): Promise<string> {
+      if (configuration.getBuildBeforeLaunch()) {
+         await make.buildTarget(make.TriggeredBy.launch, configuration.getCurrentTarget() || "");
+      }
+
+      return this.launchTargetFileName();
+    }
+
+    // Command property accessible from launch.json:
+    // the full path of the target binary, after triggering a build of the current target.
+    public async buildAndLaunchTargetPath(): Promise<string> {
+      if (configuration.getBuildBeforeLaunch()) {
+         await make.buildTarget(make.TriggeredBy.launch, configuration.getCurrentTarget() || "");
+      }
+
+      return this.launchTargetPath();
+    }
+
+    // Command property accessible from launch.json:
     // the arguments sent to the target binary, returned as array of string
     // This is used by the debug/terminal VS Code APIs.
     public launchTargetArgs(): string[] {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -6,7 +6,6 @@
 import * as fs from 'fs';
 import * as configuration from './configuration';
 import * as vscode from 'vscode';
-import { makeFullPath } from './util';
 
 let makeOutputChannel: vscode.OutputChannel | undefined;
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -6,6 +6,7 @@
 import * as fs from 'fs';
 import * as configuration from './configuration';
 import * as vscode from 'vscode';
+import { makeFullPath } from './util';
 
 let makeOutputChannel: vscode.OutputChannel | undefined;
 
@@ -35,6 +36,12 @@ function loggingLevelApplies(messageVerbosity: string | undefined): boolean {
 export function showOutputChannel(): void {
     if (makeOutputChannel) {
         makeOutputChannel.show(true);
+    }
+}
+
+export function clearOutputChannel(): void {
+    if (makeOutputChannel) {
+        makeOutputChannel.clear();
     }
 }
 

--- a/src/make.ts
+++ b/src/make.ts
@@ -140,13 +140,14 @@ async function saveAll(): Promise<boolean>  {
         } else {
             logger.message("Saving opened files failed.");
             let yesButton: string = "Yes";
+            let noButton: string = "No";
             const chosen: vscode.MessageItem | undefined = await vscode.window.showErrorMessage<vscode.MessageItem>("Saving opened files failed. Do you want to continue anyway?",
             {
                 title: yesButton,
                 isCloseAffordance: false,
             },
             {
-                title: "No",
+                title: noButton,
                 isCloseAffordance: true
             });
 

--- a/src/make.ts
+++ b/src/make.ts
@@ -44,7 +44,8 @@ export enum ConfigureBuildReturnCodeTypes {
     cancelled = -2,
     notFound = -3,
     outOfDate = -4,
-    other = -5
+    other = -5,
+    saveFailed = -6,
 }
 
 export enum Operations {
@@ -75,6 +76,7 @@ export enum TriggeredBy {
     configureBeforeTargetChange = "configure dirty (before target change), settings (configureAfterCommand)",
     configureAfterTargetChange = "settings (configureAfterCommand), command pallette (setBuildTarget)",
     configureBeforeLaunchTargetChange = "configureDirty (before launch target change), settings (configureAfterCommand)",
+    launch = "Launch (debug/run)",
 }
 
 let fileIndex: Map<string, cpp.SourceFileConfigurationItem> = new Map<string, cpp.SourceFileConfigurationItem>();
@@ -129,6 +131,32 @@ export function blockedByOp(op: Operations, showPopup: boolean = true): Operatio
     return blocker;
 }
 
+async function saveAll(): Promise<boolean>  {
+    if (configuration.getSaveBeforeBuildOrConfigure()) {
+        logger.message("Saving opened files before build.");
+        let saveSuccess: boolean = await vscode.workspace.saveAll();
+        if (saveSuccess) {
+            return true;
+        } else {
+            logger.message("Saving opened files failed.");
+            let yesButton: string = "Yes";
+            const chosen: vscode.MessageItem | undefined = await vscode.window.showErrorMessage<vscode.MessageItem>("Saving opened files failed. Do you want to continue anyway?",
+            {
+                title: yesButton,
+                isCloseAffordance: false,
+            },
+            {
+                title: "No",
+                isCloseAffordance: true
+            });
+
+            return chosen !== undefined && chosen.title === yesButton;
+        }
+    } else {
+        return true;
+    }
+}
+
 export function prepareBuildTarget(target: string, clean: boolean = false): string[] {
     let makeArgs: string[] = [];
     // Prepend the target to the arguments given in the configurations json.
@@ -170,7 +198,12 @@ export async function buildTarget(triggeredBy: TriggeredBy, target: string, clea
         return ConfigureBuildReturnCodeTypes.blocked;
     }
 
+    if (!saveAll()) {
+        return ConfigureBuildReturnCodeTypes.saveFailed;
+    }
+
     logger.showOutputChannel();
+    logger.clearOutputChannel();
 
     // Same start time for build and an eventual configure.
     let buildStartTime: number = Date.now();
@@ -771,6 +804,10 @@ export async function configure(triggeredBy: TriggeredBy, updateTargets: boolean
 
     if (blockedByOp(Operations.configure)) {
         return ConfigureBuildReturnCodeTypes.blocked;
+    }
+
+    if (!saveAll()) {
+        return ConfigureBuildReturnCodeTypes.saveFailed;
     }
 
     logger.showOutputChannel();


### PR DESCRIPTION
To be able to hook a build before debug/run via launch.json, we add 2 additional launch commands (makefile.buildAndLaunchTargetPath, makefile.buildAndLaunchTargetFileName), from the makefile.launchTargetPath family.  Invoking these is also triggering a build of the current build target, if setting makefile.buildBeforeLaunch allows.
There wasn't a need to add makefile.buildAndLaunch... for args and directory.

Very important to note that launch.json should only have one makefile.buildAnd... command defined, otherwise more builds will be spawned at the same time. Makefile Tools extension doesn't have an easy way to control this since VSCode is calling into our commands.