### PR TITLE
Update readme. Add settings doc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,21 @@ find it.
 folder. If this is the case, you will need to manually activate it by running one of the `Makefile:` commands
 from VS Code's command palette.
 
+### Pre-configuring your project
+If you need any environment variables to be set or any terminal operations to be run before configure/build
+(like the usual `./autogen.sh`, `./configure` or `vcvarsall.bat`), you need to launch VSCode from a terminal
+that is already set up according to your project requirements OR you can point the `makefile.preConfigureSript`
+setting to a batch script file and invoke it at any time via the command `makefile.preconfigure` in the pallette.
+By seting `makefile.alwaysPreConfigure` to true, you don't need to run the pre-configure command separately.
+The extension is going to invoke the script before every configure operation.
+
 ### Configuring your project
 By default, the extension will attempt to use a `make` program that resides within your $PATH to configure
 the project.  If you use a different flavor of the make tool or if it is not in your $PATH, use the
 `makefile.makePath` setting to instruct the extension where to find it.
+
+The extension can also avoid running the `make` program when it configures your project, if you point the
+`makefile.buildLog` setting to the output of a build.
 
 Now, you are ready to configure your project. If you normally just run `make` in the terminal to
 configure/build your project, you shouldn't need to do anything else at this point besides accept the prompt

--- a/docs/makefile-settings.md
+++ b/docs/makefile-settings.md
@@ -1,0 +1,30 @@
+# Configure Makefile Tools settings
+
+Makefile Tools supports a variety of settings that can be set at the user, or workspace, level via VSCode's `settings.json` file. This topic covers the available options and how they are used.
+
+## Makefile settings
+
+There is no variable substitution available for the Makefile Tools settings and we plan to implement such support in a future release.
+
+### Command substitution
+
+Makefile Tools can expand VS Code commands. For example, you can expand the path to the launch target by using the syntax `${command:makefile.launchTargetPath}`
+
+Be careful with long-running commands because it isn't specified when, or how many times, Makefile Tools will execute a command for a given expansion.
+
+Supported commands for substitution:
+
+|command|substitution|
+|-------|------------|
+|`makefile.getLaunchTargetPath`|The full path to the target executable, including the filename. The existence of the target is not validated.|
+|`makefile.getLaunchTargetDirectory`|The full path to the target executable's directory. The existence of the directory is not validated.|
+|`makefile.getLaunchTargetFileName`|The name of the target executable file without any path or extension information. The existence of the target is not validated.|
+|`makefile.getLaunchTargetArgs`|A string array describing the arguments of the current launch target.|
+|`makefile.getLaunchTargetArgsConcat`|A string describing the arguments of the current launch target concatenated in a single string and separated by space.|
+|`makefile.launchTargetPath`|The full path to the target executable, including the filename. If `makefile.buildBeforeRun` is true, invoking this substitution will also start a build.|
+|`makefile.launchTargetFileName`|The name of the target executable file without any path or extension information. If `makefile.buildBeforeRun` is true, invoking this substitution will also start a build.|
+
+## Next steps
+
+- Learn about [user vs. workspace settings](https://code.visualstudio.com/docs/getstarted/settings)
+- Explore the [Makefile Tools documentation](../README.md)

--- a/docs/makefile-settings.md
+++ b/docs/makefile-settings.md
@@ -1,16 +1,6 @@
-# Configure Makefile Tools settings
+# Command substitution
 
-Makefile Tools supports a variety of settings that can be set at the user, or workspace, level via VSCode's `settings.json` file. This topic covers the available options and how they are used.
-
-## Makefile settings
-
-There is no variable substitution available for the Makefile Tools settings and we plan to implement such support in a future release.
-
-### Command substitution
-
-Makefile Tools can expand VS Code commands. For example, you can expand the path to the launch target by using the syntax `${command:makefile.launchTargetPath}`
-
-Be careful with long-running commands because it isn't specified when, or how many times, Makefile Tools will execute a command for a given expansion.
+Makefile Tools can expand VS Code commands when invoked in `launch.json` and `tasks.json` with this syntax: `${command:makefile.launchTargetPath}`.
 
 Supported commands for substitution:
 
@@ -24,7 +14,6 @@ Supported commands for substitution:
 |`makefile.launchTargetPath`|The full path to the target executable, including the filename. If `makefile.buildBeforeRun` is true, invoking this substitution will also start a build.|
 |`makefile.launchTargetFileName`|The name of the target executable file without any path or extension information. If `makefile.buildBeforeRun` is true, invoking this substitution will also start a build.|
 
-## Next steps
+# Variable substitution
 
-- Learn about [user vs. workspace settings](https://code.visualstudio.com/docs/getstarted/settings)
-- Explore the [Makefile Tools documentation](../README.md)
+Variable substitution is not yet implemented and it will be supported in a future release.

--- a/docs/makefile-settings.md
+++ b/docs/makefile-settings.md
@@ -13,7 +13,3 @@ Supported commands for substitution:
 |`makefile.getLaunchTargetArgsConcat`|A string describing the arguments of the current launch target concatenated in a single string and separated by space.|
 |`makefile.launchTargetPath`|The full path to the target executable, including the filename. If `makefile.buildBeforeRun` is true, invoking this substitution will also start a build.|
 |`makefile.launchTargetFileName`|The name of the target executable file without any path or extension information. If `makefile.buildBeforeRun` is true, invoking this substitution will also start a build.|
-
-# Variable substitution
-
-Variable substitution is not yet implemented and it will be supported in a future release.


### PR DESCRIPTION
Updated the readme with "pre-configure" and "configuring from log" information.
Added a new document describing the settings and commands, following the CMake Tools example.
I did not list all the settings in package.json (with their name, description and default values). Let me know if you think I should add that now. The CMT document was listing a subset.