### PR TITLE
More 0.2.1 bug fixes

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -493,7 +493,7 @@ export function getCommandForConfiguration(configuration: string | undefined): v
     let makefileUsed: string | undefined = makefileConfiguration?.makefilePath || makefilePath;
     if (makefileUsed) {
         configurationMakeArgs.push("-f");
-        configurationMakeArgs.push(makefileUsed);
+        configurationMakeArgs.push(`"${makefileUsed}"`);
         // Need to rethink this (GitHub 59).
         // Some repos don't work when we automatically add -C, others don't work when we don't.
         // configurationMakeArgs.push("-C");

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -478,13 +478,14 @@ export function getCommandForConfiguration(configuration: string | undefined): v
 
     // Name of the make tool can be defined as makePath in makefile.configurations or as makefile.makePath.
     // When none defined, default to "make".
-    configurationMakeCommand = makeParsedPathConfigurations?.name || makeParsedPathSettings?.name || "make";
+    configurationMakeCommand = makeParsedPathConfigurations?.base || makeParsedPathSettings?.base || "make";
+    let configurationMakeCommandExtension: string | undefined = makeParsedPathConfigurations?.ext || makeParsedPathSettings?.ext;
 
     // Prepend the directory path, if defined in either makefile.configurations or makefile.makePath (first has priority).
     let configurationCommandPath: string = makeParsedPathConfigurations?.dir || makeParsedPathSettings?.dir || "";
     configurationMakeCommand = path.join(configurationCommandPath, configurationMakeCommand);
-    // Add the ".exe" extension on windows, otherwise the file search APIs don't find it.
-    if (process.platform === "win32") {
+    // Add the ".exe" extension on windows if no extension was specified, otherwise the file search APIs don't find it.
+    if (process.platform === "win32" && configurationMakeCommandExtension === undefined) {
         configurationMakeCommand += ".exe";
     }
 

--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -36,6 +36,7 @@ export class CppConfigurationProvider implements cpp.CustomConfigurationProvider
 
         if (!sourceFileConfiguration) {
             logger.message(`Configuration for file ${norm_path} was not found. CppTools will set a default configuration.`);
+            logger.showOutputChannel();
         }
 
         return sourceFileConfiguration;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -315,8 +315,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         return vscode.commands.executeCommand("makefile.setBuildConfiguration");
     }));
 
-    logger.showOutputChannel();
-
     configuration.readLoggingLevel();
     configuration.readExtensionOutputFolder();
     configuration.readExtensionLog();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -315,6 +315,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         return vscode.commands.executeCommand("makefile.setBuildConfiguration");
     }));
 
+    logger.showOutputChannel();
+
     configuration.readLoggingLevel();
     configuration.readExtensionOutputFolder();
     configuration.readExtensionLog();

--- a/src/make.ts
+++ b/src/make.ts
@@ -203,6 +203,7 @@ export async function buildTarget(triggeredBy: TriggeredBy, target: string, clea
         return ConfigureBuildReturnCodeTypes.saveFailed;
     }
 
+    logger.showOutputChannel();
     logger.clearOutputChannel();
 
     // Same start time for build and an eventual configure.

--- a/src/make.ts
+++ b/src/make.ts
@@ -203,7 +203,6 @@ export async function buildTarget(triggeredBy: TriggeredBy, target: string, clea
         return ConfigureBuildReturnCodeTypes.saveFailed;
     }
 
-    logger.showOutputChannel();
     logger.clearOutputChannel();
 
     // Same start time for build and an eventual configure.
@@ -293,6 +292,11 @@ export async function buildTarget(triggeredBy: TriggeredBy, target: string, clea
                 telemetry.logEvent("build", telemetryProperties, telemetryMeasures);
 
                 cancelBuild = false;
+
+                if (retc !== ConfigureBuildReturnCodeTypes.success) {
+                  logger.showOutputChannel();
+                }
+
                 return retc;
             },
         );
@@ -525,8 +529,6 @@ export async function preConfigure(triggeredBy: TriggeredBy): Promise<number> {
         return ConfigureBuildReturnCodeTypes.blocked;
     }
 
-    logger.showOutputChannel();
-
     let preConfigureStartTime: number = Date.now();
 
     let scriptFile: string | undefined = configuration.getPreConfigureScript();
@@ -588,6 +590,11 @@ export async function preConfigure(triggeredBy: TriggeredBy): Promise<number> {
                 telemetry.logEvent("preConfigure", telemetryProperties, telemetryMeasures);
 
                 cancelPreConfigure = false;
+
+                if (retc !== ConfigureBuildReturnCodeTypes.success) {
+                  logger.showOutputChannel();
+                }
+
                 return retc;
             },
         );
@@ -637,11 +644,11 @@ export async function runPreConfigureScript(progress: vscode.Progress<{}>, scrip
     if (process.platform === 'win32') {
         runCommand = "cmd";
         scriptArgs.push("/c");
-        scriptArgs.push(wrapScriptFile);
+        scriptArgs.push(`"${wrapScriptFile}"`);
     } else {
         runCommand = "/bin/bash";
         scriptArgs.push("-c");
-        scriptArgs.push(`"source ${wrapScriptFile}"`);
+        scriptArgs.push(`"source '${wrapScriptFile}"'`);
     }
 
     try {
@@ -810,8 +817,6 @@ export async function configure(triggeredBy: TriggeredBy, updateTargets: boolean
     if (!saveAll()) {
         return ConfigureBuildReturnCodeTypes.saveFailed;
     }
-
-    logger.showOutputChannel();
 
     // Same start time for configure and an eventual pre-configure.
     let configureStartTime: number = Date.now();
@@ -990,6 +995,10 @@ export async function configure(triggeredBy: TriggeredBy, updateTargets: boolean
         // Cancelled configures reach this point too, because of the finally construct.
         if (retc !== ConfigureBuildReturnCodeTypes.cancelled) {
             extension.setCompletedConfigureInSession(true);
+        }
+
+        if (retc !== ConfigureBuildReturnCodeTypes.success) {
+           logger.showOutputChannel();
         }
     }
 }

--- a/src/make.ts
+++ b/src/make.ts
@@ -629,12 +629,12 @@ export async function runPreConfigureScript(progress: vscode.Progress<{}>, scrip
     let wrapScriptOutFile: string = wrapScriptFile + ".out";
     let wrapScriptContent: string;
     if (process.platform === "win32") {
-        wrapScriptContent = `call ${scriptFile}\r\n`;
-        wrapScriptContent += `set > ${wrapScriptOutFile}`;
+        wrapScriptContent = `call "${scriptFile}"\r\n`;
+        wrapScriptContent += `set > "${wrapScriptOutFile}"`;
         wrapScriptFile += ".bat";
     } else {
-        wrapScriptContent = `source ${scriptFile}\n`;
-        wrapScriptContent += `printenv > ${wrapScriptOutFile}`;
+        wrapScriptContent = `source '${scriptFile}'\n`;
+        wrapScriptContent += `printenv > '${wrapScriptOutFile}'`;
         wrapScriptFile += ".sh";
     }
 

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -94,7 +94,7 @@ function filterSetting(value: any, key: string, defaultValue: string) : string {
     if (!value) {
         return "undefined";
     } else if (value === defaultValue) {
-        return defaultValue;
+        return "default";
     }
 
     return "...";


### PR DESCRIPTION
This addresses https://github.com/microsoft/vscode-makefile-tools/issues/134, https://github.com/microsoft/vscode-makefile-tools/issues/114 and one more file quoting scenario during pre-Configure (there's a wrapper script that we generate that needs to call the final target in quotes and also quote an output file which results from running it).