### PR TITLE
More 0.2.1 bug fixes

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -478,13 +478,14 @@ export function getCommandForConfiguration(configuration: string | undefined): v
 
     // Name of the make tool can be defined as makePath in makefile.configurations or as makefile.makePath.
     // When none defined, default to "make".
-    configurationMakeCommand = makeParsedPathConfigurations?.name || makeParsedPathSettings?.name || "make";
+    configurationMakeCommand = makeParsedPathConfigurations?.base || makeParsedPathSettings?.base || "make";
+    let configurationMakeCommandExtension: string | undefined = makeParsedPathConfigurations?.ext || makeParsedPathSettings?.ext;
 
     // Prepend the directory path, if defined in either makefile.configurations or makefile.makePath (first has priority).
     let configurationCommandPath: string = makeParsedPathConfigurations?.dir || makeParsedPathSettings?.dir || "";
     configurationMakeCommand = path.join(configurationCommandPath, configurationMakeCommand);
-    // Add the ".exe" extension on windows, otherwise the file search APIs don't find it.
-    if (process.platform === "win32") {
+    // Add the ".exe" extension on windows if no extension was specified, otherwise the file search APIs don't find it.
+    if (process.platform === "win32" && configurationMakeCommandExtension === undefined) {
         configurationMakeCommand += ".exe";
     }
 

--- a/src/make.ts
+++ b/src/make.ts
@@ -629,12 +629,12 @@ export async function runPreConfigureScript(progress: vscode.Progress<{}>, scrip
     let wrapScriptOutFile: string = wrapScriptFile + ".out";
     let wrapScriptContent: string;
     if (process.platform === "win32") {
-        wrapScriptContent = `call ${scriptFile}\r\n`;
-        wrapScriptContent += `set > ${wrapScriptOutFile}`;
+        wrapScriptContent = `call "${scriptFile}"\r\n`;
+        wrapScriptContent += `set > "${wrapScriptOutFile}"`;
         wrapScriptFile += ".bat";
     } else {
-        wrapScriptContent = `source ${scriptFile}\n`;
-        wrapScriptContent += `printenv > ${wrapScriptOutFile}`;
+        wrapScriptContent = `source '${scriptFile}'\n`;
+        wrapScriptContent += `printenv > '${wrapScriptOutFile}'`;
         wrapScriptFile += ".sh";
     }
 

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -94,7 +94,7 @@ function filterSetting(value: any, key: string, defaultValue: string) : string {
     if (!value) {
         return "undefined";
     } else if (value === defaultValue) {
-        return defaultValue;
+        return "default";
     }
 
     return "...";


### PR DESCRIPTION
This addresses #134, #114 and one more file quoting scenario during pre-Configure (there's a wrapper script that we generate that needs to call the final target in quotes and also quote an output file which results from running it).