### PR TITLE
Force English language when needed

### DIFF
--- a/src/make.ts
+++ b/src/make.ts
@@ -319,7 +319,8 @@ export async function doBuildTarget(progress: vscode.Progress<{}>, target: strin
             logger.messageNoCR(result, "Normal");
         };
 
-        const result: util.SpawnProcessResult = await util.spawnChildProcess(configuration.getConfigurationMakeCommand(), makeArgs, util.getWorkspaceRoot(), stdout, stderr);
+        // The build invocation should use the system locale.
+        const result: util.SpawnProcessResult = await util.spawnChildProcess(configuration.getConfigurationMakeCommand(), makeArgs, util.getWorkspaceRoot(), false, stdout, stderr);
         if (result.returnCode !== ConfigureBuildReturnCodeTypes.success) {
             logger.message(`Target ${target} failed to build.`);
         } else {
@@ -485,7 +486,8 @@ export async function generateParseContent(progress: vscode.Progress<{}>,
             }
         }, 5 * 1000);
 
-        const result: util.SpawnProcessResult = await util.spawnChildProcess(configuration.getConfigurationMakeCommand(), makeArgs, util.getWorkspaceRoot(), stdout, stderr);
+        // The dry-run analysis should operate on english.
+        const result: util.SpawnProcessResult = await util.spawnChildProcess(configuration.getConfigurationMakeCommand(), makeArgs, util.getWorkspaceRoot(), true, stdout, stderr);
         clearInterval(timeout);
         let elapsedTime: number = util.elapsedTimeSince(startTime);
         logger.message(`Generating dry-run elapsed time: ${elapsedTime}`);
@@ -664,7 +666,8 @@ export async function runPreConfigureScript(progress: vscode.Progress<{}>, scrip
             logger.messageNoCR(result, "Normal");
         };
 
-        const result: util.SpawnProcessResult = await util.spawnChildProcess(runCommand, scriptArgs, util.getWorkspaceRoot(), stdout, stderr);
+        // The preconfigure invocation should use the system locale.
+        const result: util.SpawnProcessResult = await util.spawnChildProcess(runCommand, scriptArgs, util.getWorkspaceRoot(), false, stdout, stderr);
         if (result.returnCode === ConfigureBuildReturnCodeTypes.success) {
             if (someErr) {
                 // Depending how the preconfigure scripts (and any inner called sub-scripts) are written,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -487,7 +487,8 @@ async function parseAnySwitchFromToolArguments(args: string, excludeArgs: string
                 `for regions "${compilerArgRegions}": "${result}"`, "Normal");
         };
 
-        const result: util.SpawnProcessResult = await util.spawnChildProcess(runCommand, scriptArgs, util.getWorkspaceRoot(), stdout, stderr);
+        // Running the compiler arguments parsing script can use the system locale.
+        const result: util.SpawnProcessResult = await util.spawnChildProcess(runCommand, scriptArgs, util.getWorkspaceRoot(), false, stdout, stderr);
         if (result.returnCode !== 0) {
             logger.messageNoCR(`The compiler args parser script '${parseCompilerArgsScriptFile}' failed with error code ${result.returnCode}`, "Normal");
         }


### PR DESCRIPTION
Force English when running executables or scripts that need to parse English words from the execution output.
This fixes https://github.com/microsoft/vscode-makefile-tools/issues/126. 