### PR TITLE
makeDirectory (-C) versus makefilePath (-f)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ It also provides convenient commands to build, debug, and run your targets.
 
 ### Activating the extension
 The extension will activate when it finds a Makefile in your `${workspaceFolder}`. If your Makefile does not
-reside in the root of your folder, use the `makefile.makefilePath` setting to instruct the extension where to
-find it.
+reside in the root of your folder, use the `makefile.makefilePath` (which generates the make switch -f)
+or `makefile.makeDirectory` (which generates thet make swich -C) settings to instruct the extension where to find it.
 > Note: the extension will not activate automatically if your Makefile is not in the root of your workspace
 folder. If this is the case, you will need to manually activate it by running one of the `Makefile:` commands
 from VS Code's command palette.

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -57,7 +57,7 @@
 | SerenityOS | [https://github.com/SerenityOS/serenity.git](https://github.com/SerenityOS/serenity.git) | | Makefile not in root:<br>Define makefile.configurations.makefilePath to "./Base/home/anon/Source/little/Makefile" and define makefile.configurations.makeArgs to \["-C ./Base/home/anon/Source/little"\] | | Yes |
 | sled | [https://github.com/shinyblink/sled.git](https://github.com/shinyblink/sled.git) | | | | Yes |
 | Strace | [https://github.com/strace/strace.git](https://github.com/strace/strace.git) | ./bootstrap && ./configure | | build log cryptic even with V=1 | Yes |
-| swig | [https://github.com/swig/swig.git](https://github.com/swig/swig.git) | autogen and configure | | Always-make causes hang<br>https://github.com/microsoft/vscode-makefile-tools/issues/98 | Yes |
+| swig | [https://github.com/swig/swig.git](https://github.com/swig/swig.git) | autogen and configure | | Always-make causes infinite loop<br>https://github.com/microsoft/vscode-makefile-tools/issues/98 | Yes |
 | Tinyvm | [https://github.com/jakogut/tinyvm.git](https://github.com/jakogut/tinyvm.git)| | | | Yes |
 | TscanCode | [https://github.com/Tencent/TscanCode.git](https://github.com/Tencent/TscanCode.git)| | Makefile not in root, set makefile.configurations.makefilePath to "./trunk/Makefile"<br>and makefile.configurations.makeArgs" to \["-C ./trunk"\]| | Yes |
 | Tundra | [https://github.com/deplinenoise/tundra.git](https://github.com/deplinenoise/tundra.git) | | | | Yes |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -68,7 +68,7 @@ If the repository needs any special commands before make is successful:
 
 If there is no Makefile in the root:
 
-- Point  **makefile.makefilePath** or makefile.configurations.makefilePath to your Makefile. Depending how the makefile is written and how paths are defined, you may need to ask make to run from that folder of the makefile instead of from the root, in which case you need to define makefile.configurations.makeArgs to include the switch &quot;-C&quot;.
+- Point  **makefile.makefilePath** or makefile.configurations.makefilePath to your Makefile (if you use the "-f" make switch). If you prefer to use the switch "-C" you can point  **makefile.makeDirectory** or makefile.configurations.makeDirectory to the folder containing your makefile.
 - Manually activate the extension by either reloading the window or running any Makefile Tools command (like Configure) from the Command Palette
 
 Launch targets missing:
@@ -88,9 +88,9 @@ If your Build targets list is too long:
 
 - Use **makefile.phonyOnlyTargets** to filter out targets that the Makefile explicitly defines as Phony
 
-Watch out for tricky lines in dryrun/build logs that may cause crashes or hangs when the extension parses content:
+Watch out for tricky lines in dryrun/build logs that may cause crashes or infinite loops when the extension parses content:
 
-- many dashes in a row (---------------------) causes hang=infinite recursion according to regexp101.com
+- many dashes in a row (---------------------) causes infinite recursion according to regexp101.com
 - LK repository dryrun has 6000 char lines and many such lines in a row, each of them is very slow (takes hours)
 - Tip: disable MAKECONFIGHEADER in make/macros.mk, to avoid the enormous echo commands from being printed
   - This can be done under a make flag that can be tied to makefile.configurations.makeArgs to only avoid the echos when in dryrun mode

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "makefile-tools",
     "displayName": "Makefile Tools",
     "description": "Provide makefile support in VS Code: C/C++ IntelliSense, build, debug/run.",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "publisher": "ms-vscode",
     "preview": true,
     "icon": "res/makefile-logo.png",
@@ -220,6 +220,10 @@
                                 "type": "string",
                                 "description": "File path to the make command"
                             },
+                            "makeDirectory": {
+                              "type": "string",
+                              "description": "Folder path passed to make via the -C switch"
+                            },
                             "makeArgs": {
                                 "type": "array",
                                 "description": "Arguments to pass to the make command",
@@ -330,6 +334,11 @@
                     "default": "make",
                     "description": "The path to the make tool",
                     "scope": "resource"
+                },
+                "makefile.makeDirectory": {
+                  "type": "string",
+                  "description": "The folder path to be passed to make via the switch -C",
+                  "scope": "resource"
                 },
                 "makefile.makefilePath": {
                     "type": "string",


### PR DESCRIPTION
Add new makeDirectory setting, improve makefile detection logic and fix words in docs.
Fix for https://github.com/microsoft/vscode-makefile-tools/issues/117.

I still need to test this more. Pushing the branch so that I move on a different linux VM and test on real world code (anything -C and -f related in our repositories docs).