### PR TITLE
Dev/andris/makefile tools/pr107 compile commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -440,14 +440,9 @@
                     "description": "Clear the output channel at the beginning of a build",
                     "scope": "resource"
                 },
-                "makefile.exportCompileCommandsFile": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Enable generation and exporting of compile_commands.json"
-                },
                 "makefile.compileCommandsPath": {
                     "type": "string",
-                    "default": "compile_commands.json",
+                    "default": ".vscode/compile_commands.json",
                     "description": "The path to the compilation database file",
                     "scope": "resource"
                 }

--- a/package.json
+++ b/package.json
@@ -442,7 +442,7 @@
                 },
                 "makefile.compileCommandsPath": {
                     "type": "string",
-                    "default": ".vscode/compile_commands.json",
+                    "default": null,
                     "description": "The path to the compilation database file",
                     "scope": "resource"
                 }

--- a/package.json
+++ b/package.json
@@ -439,6 +439,17 @@
                     "default": true,
                     "description": "Clear the output channel at the beginning of a build",
                     "scope": "resource"
+                },
+                "makefile.exportCompileCommandsFile": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enable generation and exporting of compile_commands.json"
+                },
+                "makefile.compileCommandsPath": {
+                    "type": "string",
+                    "default": "compile_commands.json",
+                    "description": "The path to the compilation database file",
+                    "scope": "resource"
                 }
             }
         },

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -289,15 +289,6 @@ export function readCompileCommandsPath(): void {
     logger.message(`compile_commands.json path: ${compileCommandsPath}`);
 }
 
-let exportCompileCommandsFile: boolean | undefined;
-export function getExportCompileCommandsFile(): boolean | undefined { return exportCompileCommandsFile; }
-export function setExportCompileCommandsFile(value: boolean): void { exportCompileCommandsFile = value; }
-export function readExportCompileCommandsFile(): void {
-    let workspaceConfiguration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("makefile");
-    exportCompileCommandsFile = workspaceConfiguration.get<boolean>("exportCompileCommandsFile");
-    logger.message(`Export compile_commands.json: ${exportCompileCommandsFile}`);
-}
-
 let additionalCompilerNames: string[] | undefined;
 export function getAdditionalCompilerNames(): string[] | undefined { return additionalCompilerNames; }
 export function setAdditionalCompilerNames(compilerNames: string[]): void { additionalCompilerNames = compilerNames; }
@@ -808,7 +799,6 @@ export async function initFromStateAndSettings(): Promise<void> {
     readBuildBeforeLaunch();
     readClearOutputBeforeBuild();
     readIgnoreDirectoryCommands();
-    readExportCompileCommandsFile();
     readCompileCommandsPath();
 
     analyzeConfigureParams();
@@ -1132,13 +1122,6 @@ export async function initFromStateAndSettings(): Promise<void> {
             let updatedIgnoreDirectoryCommands : boolean | undefined = workspaceConfiguration.get<boolean>(subKey);
             if (updatedIgnoreDirectoryCommands !== ignoreDirectoryCommands) {
                 readIgnoreDirectoryCommands();
-                updatedSettingsSubkeys.push(subKey);
-            }
-
-            subKey = "exportCompileCommandsFile";
-            let updatedExportCompileCommandsFile: boolean | undefined = workspaceConfiguration.get<boolean>(subKey);
-            if (updatedExportCompileCommandsFile !== exportCompileCommandsFile) {
-                readExportCompileCommandsFile();
                 updatedSettingsSubkeys.push(subKey);
             }
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1139,9 +1139,6 @@ export async function initFromStateAndSettings(): Promise<void> {
             let updatedExportCompileCommandsFile: boolean | undefined = workspaceConfiguration.get<boolean>(subKey);
             if (updatedExportCompileCommandsFile !== exportCompileCommandsFile) {
                 readExportCompileCommandsFile();
-                // This will trigger a reread from the filesystem of the existing
-                // compile_commands.json
-                make.clearCompileCommands();
                 updatedSettingsSubkeys.push(subKey);
             }
 
@@ -1152,9 +1149,6 @@ export async function initFromStateAndSettings(): Promise<void> {
             }
             if (updatedCompileCommandsPath !== compileCommandsPath) {
                 readCompileCommandsPath();
-                // This will trigger a reread from the filesystem of the existing
-                // compile_commands.json
-                make.clearCompileCommands();
                 updatedSettingsSubkeys.push(subKey);
             }
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -275,6 +275,29 @@ export function readConfigurationCachePath(): void {
     logger.message(`Configurations cached at ${configurationCachePath}`);
 }
 
+let compileCommandsPath: string | undefined;
+export function getCompileCommandsPath(): string | undefined { return compileCommandsPath; }
+export function setCompileCommandsPath(path: string): void { compileCommandsPath = path; }
+export function readCompileCommandsPath(): void {
+    let workspaceConfiguration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("makefile");
+
+    compileCommandsPath = workspaceConfiguration.get<string>("compileCommandsPath");
+    if (compileCommandsPath) {
+        compileCommandsPath = util.resolvePathToRoot(compileCommandsPath);
+    }
+
+    logger.message(`compile_commands.json path: ${compileCommandsPath}`);
+}
+
+let exportCompileCommandsFile: boolean | undefined;
+export function getExportCompileCommandsFile(): boolean | undefined { return exportCompileCommandsFile; }
+export function setExportCompileCommandsFile(value: boolean): void { exportCompileCommandsFile = value; }
+export function readExportCompileCommandsFile(): void {
+    let workspaceConfiguration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("makefile");
+    exportCompileCommandsFile = workspaceConfiguration.get<boolean>("exportCompileCommandsFile");
+    logger.message(`Export compile_commands.json: ${exportCompileCommandsFile}`);
+}
+
 let additionalCompilerNames: string[] | undefined;
 export function getAdditionalCompilerNames(): string[] | undefined { return additionalCompilerNames; }
 export function setAdditionalCompilerNames(compilerNames: string[]): void { additionalCompilerNames = compilerNames; }
@@ -785,6 +808,8 @@ export async function initFromStateAndSettings(): Promise<void> {
     readBuildBeforeLaunch();
     readClearOutputBeforeBuild();
     readIgnoreDirectoryCommands();
+    readExportCompileCommandsFile();
+    readCompileCommandsPath();
 
     analyzeConfigureParams();
 
@@ -1107,6 +1132,23 @@ export async function initFromStateAndSettings(): Promise<void> {
             let updatedIgnoreDirectoryCommands : boolean | undefined = workspaceConfiguration.get<boolean>(subKey);
             if (updatedIgnoreDirectoryCommands !== ignoreDirectoryCommands) {
                 readIgnoreDirectoryCommands();
+                updatedSettingsSubkeys.push(subKey);
+            }
+
+            subKey = "exportCompileCommandsFile";
+            let updatedExportCompileCommandsFile: boolean | undefined = workspaceConfiguration.get<boolean>(subKey);
+            if (updatedExportCompileCommandsFile !== exportCompileCommandsFile) {
+                readExportCompileCommandsFile();
+                updatedSettingsSubkeys.push(subKey);
+            }
+
+            subKey = "compileCommandsPath";
+            let updatedCompileCommandsPath: string | undefined = workspaceConfiguration.get<string>(subKey);
+            if (updatedCompileCommandsPath) {
+                updatedCompileCommandsPath = util.resolvePathToRoot(updatedCompileCommandsPath);
+            }
+            if (updatedCompileCommandsPath !== compileCommandsPath) {
+                readCompileCommandsPath();
                 updatedSettingsSubkeys.push(subKey);
             }
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1139,6 +1139,9 @@ export async function initFromStateAndSettings(): Promise<void> {
             let updatedExportCompileCommandsFile: boolean | undefined = workspaceConfiguration.get<boolean>(subKey);
             if (updatedExportCompileCommandsFile !== exportCompileCommandsFile) {
                 readExportCompileCommandsFile();
+                // This will trigger a reread from the filesystem of the existing
+                // compile_commands.json
+                make.clearCompileCommands();
                 updatedSettingsSubkeys.push(subKey);
             }
 
@@ -1149,6 +1152,9 @@ export async function initFromStateAndSettings(): Promise<void> {
             }
             if (updatedCompileCommandsPath !== compileCommandsPath) {
                 readCompileCommandsPath();
+                // This will trigger a reread from the filesystem of the existing
+                // compile_commands.json
+                make.clearCompileCommands();
                 updatedSettingsSubkeys.push(subKey);
             }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -137,11 +137,14 @@ export class MakefileToolsExtension {
         // of all the compiler invocations of the current configuration
         customConfigProviderItem.files.forEach(filePath => {
             let uri: vscode.Uri = vscode.Uri.file(filePath);
-            let compileCommand: parser.CompileCommand = customConfigProviderItem.compileCommands.find(command => command.file === filePath)!;
             let sourceFileConfigurationItem: cpptools.SourceFileConfigurationItem = {
                 uri,
                 configuration,
-                compileCommand
+                compileCommand: {
+                   command: customConfigProviderItem.line,
+                   directory: customConfigProviderItem.currentPath,
+                   file: filePath
+                }
             };
 
             // These are the configurations processed during the current configure.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -137,9 +137,11 @@ export class MakefileToolsExtension {
         // of all the compiler invocations of the current configuration
         customConfigProviderItem.files.forEach(filePath => {
             let uri: vscode.Uri = vscode.Uri.file(filePath);
-            let sourceFileConfigurationItem: cpp.SourceFileConfigurationItem = {
+            let compileCommand: parser.CompileCommand = customConfigProviderItem.compileCommands.find(command => command.file === filePath)!;
+            let sourceFileConfigurationItem: cpptools.SourceFileConfigurationItem = {
                 uri,
                 configuration,
+                compileCommand
             };
 
             // These are the configurations processed during the current configure.

--- a/src/make.ts
+++ b/src/make.ts
@@ -844,7 +844,6 @@ export async function configure(triggeredBy: TriggeredBy, updateTargets: boolean
     }
 
     let compileCommandsPath: string | undefined = configuration.getCompileCommandsPath();
-    let exportCompileCommandsFile: boolean | undefined = configuration.getExportCompileCommandsFile();
 
     // Identify for telemetry whether:
     //   - this configure will need to double the workload, if it needs to analyze the build targets separately.
@@ -945,7 +944,7 @@ export async function configure(triggeredBy: TriggeredBy, updateTargets: boolean
         }
 
         // Export the compile_commands.json file if the option is enabled.
-        if (exportCompileCommandsFile && compileCommandsPath && retc !== ConfigureBuildReturnCodeTypes.cancelled) {
+        if (compileCommandsPath && retc !== ConfigureBuildReturnCodeTypes.cancelled) {
             let compileCommands: parser.CompileCommand[] = ConfigurationCache.customConfigurationProvider.fileIndex.map(([, {compileCommand}]) => compileCommand);
             util.writeFile(compileCommandsPath, JSON.stringify(compileCommands, undefined, 4));
         }

--- a/src/make.ts
+++ b/src/make.ts
@@ -94,9 +94,12 @@ export function setCustomConfigurationProvider(provider: cpptools.CustomConfigur
     workspaceBrowseConfiguration = provider.workspaceBrowse;
 }
 
-let compileCommands: parser.CompileCommand[] = [];
-export function clearCompileCommands() { compileCommands = []; }
-export function addCompileCommand(compileCommand: parser.CompileCommand) { compileCommands.push(compileCommand); }
+let compileCommands: Map<string, parser.CompileCommand> = new Map<string, parser.CompileCommand>();
+export function clearCompileCommands() { compileCommands = new Map<string, parser.CompileCommand>(); }
+export function addCompileCommand(compileCommand: parser.CompileCommand) {
+    compileCommands.set(compileCommand.file, compileCommand);
+}
+export function isCompileCommandsEmpty() { return compileCommands.size === 0; }
 
 // Identifies and logs whether an operation should be prevented from running.
 // So far, the only blocking scenarios are if an ongoing configure, pre-configure or build
@@ -949,8 +952,12 @@ export async function configure(triggeredBy: TriggeredBy, updateTargets: boolean
 
         // Export the compile_commands.json file if the option is enabled.
         if (exportCompileCommandsFile && compileCommandsPath && retc !== ConfigureBuildReturnCodeTypes.cancelled) {
-            // Pretty print the output for easier inspection
-            util.writeFile(compileCommandsPath, JSON.stringify(compileCommands, undefined, 4));
+            if (!isCompileCommandsEmpty()) {
+                // Pretty print the output for easier inspection
+                util.writeFile(compileCommandsPath, JSON.stringify(Array.from(compileCommands.values()), undefined, 4));
+            } else {
+                logger.message("The configuration was successful but produced an empty compile_commands.json. Discarding it");
+            }
         }
 
         let newBuildTarget: string | undefined = configuration.getCurrentTarget();
@@ -1120,6 +1127,35 @@ async function parseTargets(progress: vscode.Progress<{}>, cancel: vscode.Cancel
     };
 }
 
+// Tries to load a preexisting compile_commands.json.
+function tryLoadingCompileCommandsFromFile(): boolean {
+    let compileCommandsPath: string | undefined = configuration.getCompileCommandsPath();
+    if (compileCommandsPath) {
+        clearCompileCommands();
+
+        let content: string | undefined = util.readFile(compileCommandsPath);
+        if (content) {
+            try {
+                logger.message(`Reading previous compile_commands.json: ${compileCommandsPath}`);
+                let compileCommandsList: parser.CompileCommand[] = JSON.parse(content);
+                compileCommandsList.forEach(compileCommand => {
+                    addCompileCommand(compileCommand);
+                });
+            } catch (e) {
+                logger.message("An error occured while parsing the previous compile_commands.json");
+                return false;
+            }
+        } else {
+            // If there is no compile_commands.json and we request to build one
+            // the configuration needs to be clean
+            logger.message(`There is no previous compile_commands.json at ${compileCommandsPath}`);
+            return false;
+        }
+    }
+
+    return true;
+}
+
 async function updateProvider(progress: vscode.Progress<{}>, cancel: vscode.CancellationToken,
                               dryRunOutput: string, recursive: boolean = false): Promise<ConfigureSubphaseStatus> {
     if (cancel.isCancellationRequested) {
@@ -1141,16 +1177,15 @@ async function updateProvider(progress: vscode.Progress<{}>, cancel: vscode.Canc
         extension.buildCustomConfigurationProvider(customConfigProviderItem);
     };
 
-	let onFoundCompileCommandsItem: any = (compileCommand: parser.CompileCommand): void => {
-		addCompileCommand(compileCommand);
-	}
+    let onFoundCompileCommandsItem: any = (compileCommand: parser.CompileCommand): void => {
+        addCompileCommand(compileCommand);
+    }
 
     // Empty the cummulative browse path before we start a new parse for custom configuration.
     // We can empty even if the configure is not clean, because the new browse paths will be appended
     // to the previous browse paths.
     extension.clearCummulativeBrowsePath();
-	// Clear the previous compilation command database
-	clearCompileCommands();
+    // The compileCommands have already been cleared if necessary
     let retc: number = await parser.parseCustomConfigProvider(cancel, dryRunOutput, onStatus, onFoundCustomConfigProviderItem, onFoundCompileCommandsItem);
     if (retc !== ConfigureBuildReturnCodeTypes.cancelled) {
         // If this configure is clean, overwrite the final file index, otherwise merge with it.
@@ -1316,6 +1351,26 @@ export async function doConfigure(progress: vscode.Progress<{}>, cancel: vscode.
         }
     } else {
         logger.message("Loading configurations from cache is not necessary.", "Verbose");
+    }
+
+    // Before generating the dryrun output, if compile_commands.json generation
+    // is requested, but the compileCommands variable is empty (possibly because
+    // of some error that interrupted a previous config or some error while
+    // reading the old file) we need to request a clean configuration.
+    let exportCompileCommandsFile: boolean | undefined = configuration.getExportCompileCommandsFile();
+    if (exportCompileCommandsFile) {
+        if (getConfigureIsClean()) {
+            // No need to do any more checks, the compileCommands are going to
+            // be overwritten anyways
+            clearCompileCommands();
+        } else if (isCompileCommandsEmpty()) {
+            if (!tryLoadingCompileCommandsFromFile()) {
+                // More detailed log has been printed already
+                logger.message("Running clean configure instead.");
+                setConfigureIsInBackground(false);
+                setConfigureIsClean(true);
+            }
+        }
     }
 
     // This generates the dryrun output (saving it on disk) or reads an alternative build log.

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -783,12 +783,25 @@ export interface CustomConfigProviderItem {
     windowsSDKVersion?: string;
 }
 
+// Structure used to describe a compilation command. Reference documentation is
+// hosted here https://clang.llvm.org/docs/JSONCompilationDatabase.html
+export interface CompileCommand {
+    directory: string;
+    file: string;
+    command: string;
+    arguments?: string[];
+    output?: string;
+}
+
 // Parse the output of the make dry-run command in order to provide CppTools
 // with information about includes, defines, compiler path....etc...
-// as needed by CustomConfigurationProvider
+// as needed by CustomConfigurationProvider. In addition generate a
+// CompileCommand entry for every file with a compiler invocation to build
+// a compile_commands.json file.
 export async function parseCustomConfigProvider(cancel: vscode.CancellationToken, dryRunOutputStr: string,
                                                 statusCallback: (message: string) => void,
-                                                onFoundCustomConfigProviderItem: (customConfigProviderItem: CustomConfigProviderItem) => void): Promise<number> {
+                                                onFoundCustomConfigProviderItem: (customConfigProviderItem: CustomConfigProviderItem) => void,
+												onFoundCompileCommandsItem: (compileCommand: CompileCommand) => void): Promise<number> {
     if (cancel.isCancellationRequested) {
         return make.ConfigureBuildReturnCodeTypes.cancelled;
     }
@@ -903,92 +916,17 @@ export async function parseCustomConfigProvider(cancel: vscode.CancellationToken
                         }
                     });
                 }
-            } // if (compilerTool) {
 
-            index++;
-            if (index === numberOfLines) {
-                done = true;
-            }
-
-            chunkIndex++;
-        } // while loop
-    } // doParsingChunk function
-
-    while (!done) {
-        if (cancel.isCancellationRequested) {
-            break;
-        }
-
-        await util.scheduleAsyncTask(doParsingChunk);
-    }
-
-    return cancel.isCancellationRequested ? make.ConfigureBuildReturnCodeTypes.cancelled : make.ConfigureBuildReturnCodeTypes.success;
-}
-
-// Structure used to describe a compilation command. Reference documentation is
-// hosted here https://clang.llvm.org/docs/JSONCompilationDatabase.html
-export interface CompileCommand {
-    directory: string;
-    file: string;
-    command: string;
-    arguments?: string[];
-    output?: string;
-};
-
-// Parse the output of the make dry-run command in order to create a
-// CompilationCommand entry for each file, to be able to generate a
-// compile_commands.json file.
-export async function parseCompileCommands(cancel: vscode.CancellationToken,
-                                           dryRunOutputStr: string,
-                                           statusCallback: (message: string) => void,
-                                           onFoundCompileCommandsItem: (compileCommand: CompileCommand) => void): Promise<number> {
-    if (cancel.isCancellationRequested) {
-        return make.ConfigureBuildReturnCodeTypes.cancelled;
-    }
-
-    logger.message('Parsing dry-run output to generate compile_commands.json database.', "Normal");
-
-    // Current path starts with workspace root and can be modified
-    // with prompt commands like cd, cd-, pushd/popd or with -C make switch
-    let currentPath: string = vscode.workspace.rootPath || "";
-    let currentPathHistory: string[] = [currentPath];
-
-    // Read the dry-run output line by line, searching for compilers and directory changing commands
-    // to construct information for the CppTools custom configuration
-    let dryRunOutputLines: string[] = dryRunOutputStr.split("\n");
-    let numberOfLines: number = dryRunOutputLines.length;
-    let index: number = 0;
-    let done: boolean = false;
-
-    async function doParsingChunk(): Promise<void> {
-        let chunkIndex: number = 0;
-        while (index < numberOfLines && chunkIndex <= chunkSize) {
-            if (cancel.isCancellationRequested) {
-                break;
-            }
-
-            let line: string = dryRunOutputLines[index];
-
-            statusCallback("Generating compile_commands.json");
-            currentPathHistory = await currentPathAfterCommand(line, currentPathHistory);
-            currentPath = currentPathHistory[currentPathHistory.length - 1];
-
-            let compilerTool: ToolInvocation | undefined = await parseLineAsTool(line, compilers, currentPath);
-            if (compilerTool) {
-                logger.message("Found compiler command: " + line, "Verbose");
-
-                // Parse the source files
-                let files: string[] = parseFilesFromToolArguments(compilerTool.arguments, sourceFileExtensions);
-                files = await util.makeFullPaths(files, currentPath);
-
-                files.forEach(file => {
+				// Generate a CompileCommands entry for each file, to be able
+				// to generate a compile_commands.json file.
+				files.forEach(file => {
                     onFoundCompileCommandsItem({
                         directory: currentPath,
                         command: line,
                         file: file
                     });
                 });
-            }
+            } // if (compilerTool) {
 
             index++;
             if (index === numberOfLines) {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -791,7 +791,8 @@ export interface CustomConfigProviderItem {
     compilerArgs: string[];
     files: string[];
     windowsSDKVersion?: string;
-    compileCommands: CompileCommand[];
+    currentPath: string;
+    line: string;
 }
 
 // Parse the output of the make dry-run command in order to provide CppTools
@@ -897,18 +898,8 @@ export async function parseCustomConfigProvider(cancel: vscode.CancellationToken
                         // More standard validation and defaults, in the context of the whole command.
                     let standard: util.StandardVersion = parseStandard(ext.extension.getCppToolsVersion(), standardStr, language);
 
-                    // Generate compilation command
-                    let compileCommands: CompileCommand[] = [];
-                    files.forEach(file => {
-                        compileCommands.push({
-                            file: file,
-                            directory: currentPath,
-                            command: line
-                        });
-                    });
-
                     if (ext.extension) {
-                        onFoundCustomConfigProviderItem({ defines, includes, forcedIncludes, standard, intelliSenseMode, compilerFullPath, compilerArgs, files, windowsSDKVersion, compileCommands });
+                        onFoundCustomConfigProviderItem({ defines, includes, forcedIncludes, standard, intelliSenseMode, compilerFullPath, compilerArgs, files, windowsSDKVersion, currentPath, line });
                     }
                 } else {
                     // If the compiler command is mixing c and c++ source files, send a custom configuration for each of the source files separately,
@@ -923,15 +914,8 @@ export async function parseCustomConfigProvider(cancel: vscode.CancellationToken
                         // More standard validation and defaults, in the context of each source file.
                         let standard: util.StandardVersion = parseStandard(ext.extension.getCppToolsVersion(), standardStr, language);
 
-                        // Generate compilation command
-                        let compileCommands: CompileCommand[] = [{
-                            file: file,
-                            directory: currentPath,
-                            command: line
-                        }];
-
                         if (ext.extension) {
-                            onFoundCustomConfigProviderItem({ defines, includes, forcedIncludes, standard, intelliSenseMode, compilerFullPath, compilerArgs, files: [file], windowsSDKVersion, compileCommands });
+                            onFoundCustomConfigProviderItem({ defines, includes, forcedIncludes, standard, intelliSenseMode, compilerFullPath, compilerArgs, files: [file], windowsSDKVersion, currentPath, line });
                         }
                     });
                 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -801,12 +801,12 @@ export interface CompileCommand {
 export async function parseCustomConfigProvider(cancel: vscode.CancellationToken, dryRunOutputStr: string,
                                                 statusCallback: (message: string) => void,
                                                 onFoundCustomConfigProviderItem: (customConfigProviderItem: CustomConfigProviderItem) => void,
-												onFoundCompileCommandsItem: (compileCommand: CompileCommand) => void): Promise<number> {
+                                                onFoundCompileCommandsItem: (compileCommand: CompileCommand) => void): Promise<number> {
     if (cancel.isCancellationRequested) {
         return make.ConfigureBuildReturnCodeTypes.cancelled;
     }
 
-    logger.message('Parsing dry-run output for CppTools Custom Configuration Provider.', "Normal");
+    logger.message('Parsing dry-run output for CppTools Custom Configuration Provider and compile_commands.json generation.', "Normal");
 
     // Current path starts with workspace root and can be modified
     // with prompt commands like cd, cd-, pushd/popd or with -C make switch
@@ -917,9 +917,9 @@ export async function parseCustomConfigProvider(cancel: vscode.CancellationToken
                     });
                 }
 
-				// Generate a CompileCommands entry for each file, to be able
-				// to generate a compile_commands.json file.
-				files.forEach(file => {
+                // Generate a CompileCommands entry for each file, to be able
+                // to generate a compile_commands.json file.
+                files.forEach(file => {
                     onFoundCompileCommandsItem({
                         directory: currentPath,
                         command: line,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -807,7 +807,7 @@ export async function parseCustomConfigProvider(cancel: vscode.CancellationToken
         return make.ConfigureBuildReturnCodeTypes.cancelled;
     }
 
-    logger.message('Parsing dry-run output for CppTools Custom Configuration Provider and compile_commands.json generation.', "Normal");
+    logger.message('Parsing dry-run output for CppTools Custom Configuration Provider.', "Normal");
 
     // Current path starts with workspace root and can be modified
     // with prompt commands like cd, cd-, pushd/popd or with -C make switch


### PR DESCRIPTION
Based on https://github.com/microsoft/vscode-makefile-tools/pull/107. 

I only did 2 changes: I thought that the boolean setting exportCompileCommandsFile was redundant. As we also have other similar settings that control generating or not an output file (like extensionLog), it's enough to have a string variable with a ".vscode/compile_commands.json" default. When not defined in settings.json, we don't generate anything. When the user starts to write it in the settings.json, the default pops up.

Other changes were around some refactoring of what arguments we pass from parser.ts helpers into cpptools.ts custom provider construction APIs and optimize some forEach loops.

To view how the differences look like between my suggestion and the original PR, see https://github.com/rapgenic/vscode-makefile-tools/pull/1. 