### PR TITLE
Initial support for problem matchers

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,6 +196,25 @@
                 "title": "Makefile: Reset the Makefile Tools Extension workspace state (For troubleshooting)"
             }
         ],
+        "problemMatchers": [
+            {
+              "name": "gcc",
+              "source": "gcc",
+              "owner": "makefile-tools",
+              "fileLocation": [
+                "autoDetect",
+                "${workspaceFolder}"
+              ],
+              "pattern": {
+                "regexp": "^(.*?):(\\d+):(\\d*):?\\s+(?:fatal\\s+)?(warning|error):\\s+(.*)$",
+                "file": 1,
+                "line": 2,
+                "column": 3,
+                "severity": 4,
+                "message": 5
+              }
+            }
+          ],
         "configuration": {
             "type": "object",
             "title": "makefile",
@@ -231,6 +250,14 @@
                                     "type": "string"
                                 },
                                 "default": []
+                            },
+                            "problemMatchers": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "default": [],
+                                "description": "Problem matcher names to use when building the current target"
                             },
                             "buildLog": {
                                 "type": "string",
@@ -336,9 +363,9 @@
                     "scope": "resource"
                 },
                 "makefile.makeDirectory": {
-                  "type": "string",
-                  "description": "The folder path to be passed to make via the switch -C",
-                  "scope": "resource"
+                    "type": "string",
+                    "description": "The folder path to be passed to make via the switch -C",
+                    "scope": "resource"
                 },
                 "makefile.makefilePath": {
                     "type": "string",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -46,6 +46,9 @@ export interface MakefileConfiguration {
     // don't use more than one argument in a string
     makeArgs?: string[];
 
+    // list of problem matcher names to be used when building the current target
+    problemMatchers?: string[];
+
     // a pre-generated build log, from which it is preffered to parse from,
     // instead of the dry-run output of the make tool
     buildLog?: string;
@@ -493,6 +496,10 @@ let configurationMakeArgs: string[] = [];
 export function getConfigurationMakeArgs(): string[] { return configurationMakeArgs; }
 export function setConfigurationMakeArgs(args: string[]): void { configurationMakeArgs = args; }
 
+let configurationProblemMatchers: string[] = [];
+export function getConfigurationProblemMatchers(): string[] { return configurationProblemMatchers; }
+export function setConfigurationProblemMatchers(problemMatchers: string[]): void { configurationProblemMatchers = problemMatchers; }
+
 let configurationBuildLog: string | undefined;
 export function getConfigurationBuildLog(): string | undefined { return configurationBuildLog; }
 export function setConfigurationBuildLog(name: string): void { configurationBuildLog = name; }
@@ -503,6 +510,7 @@ export function setConfigurationBuildLog(name: string): void { configurationBuil
 function analyzeConfigureParams(): void {
     getBuildLogForConfiguration(currentMakefileConfiguration);
     getCommandForConfiguration(currentMakefileConfiguration);
+    getProblemMatchersForConfiguration(currentMakefileConfiguration);
 }
 
 // Helper to find in the array of MakefileConfiguration which command/args correspond to a configuration name.
@@ -631,6 +639,17 @@ export function getCommandForConfiguration(configuration: string | undefined): v
             telemetry.logEvent("makefileNotFound", telemetryProperties);
         }
     }
+}
+
+// Helper to find in the array of MakefileConfiguration which problemMatchers correspond to a configuration name
+export function getProblemMatchersForConfiguration(configuration: string | undefined): void {
+    let makefileConfiguration: MakefileConfiguration | undefined = makefileConfigurations.find(k => {
+        if (k.name === configuration) {
+            return { ...k, keep: true };
+        }
+    });
+
+    configurationProblemMatchers = makefileConfiguration?.problemMatchers || [];
 }
 
 // Helper to find in the array of MakefileConfiguration which buildLog correspond to a configuration name

--- a/src/make.ts
+++ b/src/make.ts
@@ -193,6 +193,8 @@ let curPID: number = -1;
 export function getCurPID(): number { return curPID; }
 export function setCurPID(pid: number): void { curPID = pid; }
 
+const makefileBuildTaskName: string = "Makefile Tools Build Task";
+
 export async function buildTarget(triggeredBy: TriggeredBy, target: string, clean: boolean = false): Promise<number> {
     if (blockedByOp(Operations.build)) {
         return ConfigureBuildReturnCodeTypes.blocked;
@@ -201,9 +203,6 @@ export async function buildTarget(triggeredBy: TriggeredBy, target: string, clea
     if (!saveAll()) {
         return ConfigureBuildReturnCodeTypes.saveFailed;
     }
-
-    logger.showOutputChannel();
-    logger.clearOutputChannel();
 
     // Same start time for build and an eventual configure.
     let buildStartTime: number = Date.now();
@@ -250,28 +249,35 @@ export async function buildTarget(triggeredBy: TriggeredBy, target: string, clea
                     logger.message("The user is cancelling the build...");
                     cancelBuild = true;
 
-                    // Kill make and all its children subprocesses.
-                    logger.message(`Attempting to kill the make process (PID = ${curPID}) and all its children subprocesses...`);
-                    await vscode.window.withProgress({
-                            location: vscode.ProgressLocation.Notification,
-                            title: "Cancelling build",
-                            cancellable: false,
-                        },
-                        async (progress) => {
-                            await util.killTree(progress, curPID);
-                        });
+                    // Kill the task that is used for building.
+                    // This will take care of all processes that were spawned.
+                    let myTask = vscode.tasks.taskExecutions.find(tsk => {
+                        if (tsk.task.name === makefileBuildTaskName) {
+                            return tsk;
+                        }
+                    });
+
+                    logger.message(`Killing task ${makefileBuildTaskName}.`);
+                    myTask?.terminate();
                 });
 
                 setIsBuilding(true);
+
+                // If required by the "makefile.clearOutputBeforeBuild" setting,
+                // we need to clear the terminal output when "make"-ing target "clean"
+                // (but not when "make"-ing the following intended target, so that we see both together)
+                // or when "make"-ing the intended target in case of a not-clean build.
+                let clearOutput: boolean = configuration.getClearOutputBeforeBuild() || false;
+
                 if (clean) {
                     // We don't need to track the return code for 'make "clean"'.
                     // We want to proceed with the 'make "target"' step anyway.
                     // The relevant return code for telemetry will be the second one.
-                    // If the clean step fails, doBuildTarget will print an error message in the log.
-                    await doBuildTarget(progress, "clean");
+                    // If the clean step fails, doBuildTarget will print an error message in the terminal.
+                    await doBuildTarget(progress, "clean", clearOutput);
                 }
 
-                let retc: number = await doBuildTarget(progress, target);
+                let retc: number = await doBuildTarget(progress, target, clearOutput && !clean);
 
                 // We need to know whether this build was cancelled by the user
                 // more than the real exit code of the make process in this circumstance.
@@ -301,10 +307,6 @@ export async function buildTarget(triggeredBy: TriggeredBy, target: string, clea
 
                 cancelBuild = false;
 
-                if (retc !== ConfigureBuildReturnCodeTypes.success) {
-                  logger.showOutputChannel();
-                }
-
                 return retc;
             },
         );
@@ -313,7 +315,7 @@ export async function buildTarget(triggeredBy: TriggeredBy, target: string, clea
     }
 }
 
-export async function doBuildTarget(progress: vscode.Progress<{}>, target: string): Promise<number> {
+export async function doBuildTarget(progress: vscode.Progress<{}>, target: string, clearTerminalOutput: boolean): Promise<number> {
     let makeArgs: string[] = prepareBuildTarget(target);
     try {
         // Append without end of line since there is one already included in the stdout/stderr fragments
@@ -326,14 +328,32 @@ export async function doBuildTarget(progress: vscode.Progress<{}>, target: strin
             logger.messageNoCR(result, "Normal");
         };
 
-        // The build invocation should use the system locale.
-        const result: util.SpawnProcessResult = await util.spawnChildProcess(configuration.getConfigurationMakeCommand(), makeArgs, util.getWorkspaceRoot(), false, stdout, stderr);
-        if (result.returnCode !== ConfigureBuildReturnCodeTypes.success) {
+        let myTaskCommand: string = `${configuration.getConfigurationMakeCommand()} ${makeArgs.join(" ")}`;
+        let myTask: vscode.Task = new vscode.Task({type: "shell", group: "build", label: makefileBuildTaskName},
+            vscode.TaskScope.Workspace, makefileBuildTaskName, "makefile", new vscode.ShellExecution(myTaskCommand));
+        
+        myTask.problemMatchers = configuration.getConfigurationProblemMatchers();
+        myTask.presentationOptions.clear = clearTerminalOutput;
+        myTask.presentationOptions.showReuseMessage = true;
+
+        await vscode.tasks.executeTask(myTask);
+
+        const result: number = await(new Promise<number>(resolve => {
+            let disposable = vscode.tasks.onDidEndTaskProcess(e => {
+                if (e.execution.task.name === makefileBuildTaskName) {
+                    disposable.dispose();
+                    resolve(e.exitCode);
+                }
+            });
+        }));
+
+        if (result !== ConfigureBuildReturnCodeTypes.success) {
             logger.message(`Target ${target} failed to build.`);
         } else {
             logger.message(`Target ${target} built successfully.`);
         }
-        return result.returnCode;
+
+        return result;
     } catch (error) {
         // No need for notification popup, since the build result is visible already in the output channel
         logger.message(error);


### PR DESCRIPTION
Implement feature https://github.com/microsoft/vscode-makefile-tools/issues/7.

Didn't test yet with relative paths of multiple makefile projects in various folders, as commented in https://github.com/microsoft/vscode-makefile-tools/issues/178. Will see how this works for such complex setup.