### PR TITLE
Hide makefile commands and UI for non makefile projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
         "onCommand:makefile.outline.cleanConfigure",
         "onCommand:makefile.outline.preConfigure",
         "onCommand:makefile.resetState",
-        "onView:makefile.outline",
         "workspaceContains:makefile",
         "workspaceContains:Makefile",
         "workspaceContains:GNUmakefile"
@@ -371,7 +370,11 @@
                 },
                 "makefile.dryrunSwitches": {
                     "type": "array",
-                    "default": ["--always-make", "--keep-going", "--print-directory"],
+                    "default": [
+                        "--always-make",
+                        "--keep-going",
+                        "--print-directory"
+                    ],
                     "description": "Arguments to pass to the dry-run make invocation",
                     "items": {
                         "type": "string"
@@ -469,6 +472,7 @@
                 {
                     "id": "makefile__viewContainer",
                     "title": "Makefile",
+                    "when": "makefile:fullFeatureSet",
                     "icon": "res/viewcontainer.svg"
                 }
             ]
@@ -477,11 +481,86 @@
             "makefile__viewContainer": [
                 {
                     "id": "makefile.outline",
+                    "when": "makefile:fullFeatureSet",
                     "name": ""
                 }
             ]
         },
         "menus": {
+            "commandPalette": [
+                {
+                    "command": "makefile.preConfigure",
+                    "when": "makefile:fullFeatureSet"
+                },
+                {
+                    "command": "makefile.buildTarget",
+                    "when": "makefile:fullFeatureSet"
+                },
+                {
+                    "command": "makefile.buildCleanTarget",
+                    "when": "makefile:fullFeatureSet"
+                },
+                {
+                    "command": "makefile.buildAll",
+                    "when": "makefile:fullFeatureSet"
+                },
+                {
+                    "command": "makefile.buildCleanAll",
+                    "when": "makefile:fullFeatureSet"
+                },
+                {
+                    "command": "makefile.launchDebug",
+                    "when": "makefile:fullFeatureSet"
+                },
+                {
+                    "command": "makefile.launchRun",
+                    "when": "makefile:fullFeatureSet"
+                },
+                {
+                    "command": "makefile.setBuildConfiguration",
+                    "when": "makefile:fullFeatureSet"
+                },
+                {
+                    "command": "makefile.setBuildTarget",
+                    "when": "makefile:fullFeatureSet"
+                },
+                {
+                    "command": "makefile.setLaunchConfiguration",
+                    "when": "makefile:fullFeatureSet"
+                },
+                {
+                    "command": "makefile.outline.preConfigure",
+                    "when": "makefile:fullFeatureSet"
+                },
+                {
+                    "command": "makefile.outline.buildTarget",
+                    "when": "makefile:fullFeatureSet"
+                },
+                {
+                    "command": "makefile.outline.buildCleanTarget",
+                    "when": "makefile:fullFeatureSet"
+                },
+                {
+                    "command": "makefile.outline.launchDebug",
+                    "when": "makefile:fullFeatureSet"
+                },
+                {
+                    "command": "makefile.outline.launchRun",
+                    "when": "makefile:fullFeatureSet"
+                },
+                {
+                    "command": "makefile.outline.setBuildConfiguration",
+                    "when": "makefile:fullFeatureSet"
+                },
+                {
+                    "command": "makefile.outline.setBuildTarget",
+                    "when": "makefile:fullFeatureSet"
+                },
+                {
+                    "command": "makefile.outline.setLaunchConfiguration",
+                    "when": "makefile:fullFeatureSet"
+                }
+            ],
             "view/title": [
                 {
                     "command": "makefile.outline.preConfigure",
@@ -500,12 +579,12 @@
                 },
                 {
                     "command": "makefile.outline.buildTarget",
-                    "when": "view == makefile.outline",
+                    "when": "makefile:fullFeatureSet",
                     "group": "navigation@1"
                 },
                 {
                     "command": "makefile.outline.buildCleanTarget",
-                    "when": "view == makefile.outline",
+                    "when": "makefile:fullFeatureSet",
                     "group": "1_makefileOutline@4"
                 },
                 {
@@ -537,12 +616,12 @@
                 },
                 {
                     "command": "makefile.outline.buildTarget",
-                    "when": "view == makefile.outline && viewItem =~ /nodeType=buildTarget/",
+                    "when": "makefile:fullFeatureSet",
                     "group": "1_stateActions@1"
                 },
                 {
                     "command": "makefile.outline.buildCleanTarget",
-                    "when": "view == makefile.outline && viewItem =~ /nodeType=buildTarget/",
+                    "when": "makefile:fullFeatureSet",
                     "group": "1_stateActions@2"
                 },
                 {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -187,6 +187,7 @@ export class MakefileToolsExtension {
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
     statusBar = ui.getUI();
+    await vscode.commands.executeCommand('setContext', "makefile:fullFeatureSet", "true");
     extension = new MakefileToolsExtension(context);
 
     telemetry.activate();


### PR DESCRIPTION
Addresses https://github.com/microsoft/vscode-makefile-tools/issues/181.
Hide makefile commands from palette and c/c++ tab from the left side panel for projects that don't activate.

Currently, since the activation depends on makefiles being present only at the root level (no subdirectories yet), we can simply define the state boolean (which controls the visibility of these elements) at the beginning of the activation method.

For the example of CppTools Extension folder (given as repro in issue 181), activation was not occurring. Simply these elements were visible and it looks like it was by design, despite no activation.

In future we may need to move to an activation that would detect makefiles anywhere. Then we would have set the state boolean more carefully. Opened new work item: https://github.com/microsoft/vscode-makefile-tools/issues/222. 

This PR does not address the situation of dealing with dual activation: Makefile Tools together with CMake Tools (which is work item https://github.com/microsoft/vscode-makefile-tools/issues/30).

The entry-point commands that ensure the extension can always activate are "configure", "cleanConfigure" and "reset state". We had cases in CMake Tools when "reset state" being hidden for non CMake projects was very inconvenient so I thought to match the rule here.