### PR TITLE
Fix for GitHub issues for 0.3.1 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,9 +67,9 @@
         "onCommand:makefile.outline.cleanConfigure",
         "onCommand:makefile.outline.preConfigure",
         "onCommand:makefile.resetState",
-        "workspaceContains:makefile",
-        "workspaceContains:Makefile",
-        "workspaceContains:GNUmakefile"
+        "workspaceContains:**/makefile",
+        "workspaceContains:**/Makefile",
+        "workspaceContains:**/GNUmakefile"
     ],
     "main": "./out/src/extension.js",
     "contributes": {

--- a/package.json
+++ b/package.json
@@ -606,12 +606,12 @@
                 },
                 {
                     "command": "makefile.outline.buildTarget",
-                    "when": "makefile:fullFeatureSet",
+                    "when": "view == makefile.outline",
                     "group": "navigation@1"
                 },
                 {
                     "command": "makefile.outline.buildCleanTarget",
-                    "when": "makefile:fullFeatureSet",
+                    "when": "view == makefile.outline",
                     "group": "1_makefileOutline@4"
                 },
                 {
@@ -643,12 +643,12 @@
                 },
                 {
                     "command": "makefile.outline.buildTarget",
-                    "when": "makefile:fullFeatureSet",
+                    "when": "view == makefile.outline && viewItem =~ /nodeType=buildTarget/",
                     "group": "1_stateActions@1"
                 },
                 {
                     "command": "makefile.outline.buildCleanTarget",
-                    "when": "makefile:fullFeatureSet",
+                    "when": "view == makefile.outline && viewItem =~ /nodeType=buildTarget/",
                     "group": "1_stateActions@2"
                 },
                 {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -551,7 +551,7 @@ export function getCommandForConfiguration(configuration: string | undefined): v
     let makefileUsed: string | undefined = makefileConfiguration?.makefilePath || makefilePath;
     if (makefileUsed) {
         configurationMakeArgs.push("-f");
-        configurationMakeArgs.push(`"${makefileUsed}"`);
+        configurationMakeArgs.push(`${makefileUsed}`);
         // Need to rethink this (GitHub 59).
         // Some repos don't work when we automatically add -C, others don't work when we don't.
         // configurationMakeArgs.push("-C");
@@ -563,7 +563,7 @@ export function getCommandForConfiguration(configuration: string | undefined): v
     let makeDirectoryUsed: string | undefined = makefileConfiguration?.makeDirectory || makeDirectory;
     if (makeDirectoryUsed) {
         configurationMakeArgs.push("-C");
-        configurationMakeArgs.push(`"${makeDirectoryUsed}"`);
+        configurationMakeArgs.push(`${makeDirectoryUsed}`);
     }
 
     if (configurationMakeCommand) {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -67,7 +67,7 @@ export function getCurrentMakefileConfiguration(): string { return currentMakefi
 export function setCurrentMakefileConfiguration(configuration: string): void {
     currentMakefileConfiguration = configuration;
     statusBar.setConfiguration(currentMakefileConfiguration);
-    logger.message("Setting configuration - " + currentMakefileConfiguration);
+    logger.message(`Setting configuration - ${currentMakefileConfiguration}`);
     analyzeConfigureParams();
 }
 
@@ -163,7 +163,7 @@ function readBuildLog(): void {
     buildLog = workspaceConfiguration.get<string>("buildLog");
     if (buildLog) {
         buildLog = util.resolvePathToRoot(buildLog);
-        logger.message('Build log defined at "' + buildLog + '"');
+        logger.message(`Build log defined at "${buildLog}"`);
         if (!util.checkFileExistsSync(buildLog)) {
             logger.message("Build log not found on disk.");
         }
@@ -567,7 +567,7 @@ export function getCommandForConfiguration(configuration: string | undefined): v
     }
 
     if (configurationMakeCommand) {
-        logger.message("Deduced command '" + configurationMakeCommand + " " + configurationMakeArgs.join(" ") + "' for configuration " + configuration);
+        logger.message(`Deduced command '${configurationMakeCommand} ${configurationMakeArgs.join(" ")}' for configuration "${configuration}"`);
     }
 
     // Validation and warnings about properly defining the makefile and make tool.
@@ -637,6 +637,9 @@ export function getCommandForConfiguration(configuration: string | undefined): v
             };
 
             telemetry.logEvent("makefileNotFound", telemetryProperties);
+            vscode.commands.executeCommand('setContext', "makefile:fullFeatureSet", false);
+        } else {
+            vscode.commands.executeCommand('setContext', "makefile:fullFeatureSet", true);
         }
     }
 }
@@ -663,11 +666,11 @@ export function getBuildLogForConfiguration(configuration: string | undefined): 
     configurationBuildLog = makefileConfiguration?.buildLog;
 
     if (configurationBuildLog) {
-        logger.message('Found build log path setting "' + configurationBuildLog + '" defined for configuration "' + configuration);
+        logger.message(`Found build log path setting "${configurationBuildLog}" defined for configuration "${configuration}"`);
 
         if (!path.isAbsolute(configurationBuildLog)) {
             configurationBuildLog = path.join(util.getWorkspaceRoot(), configurationBuildLog);
-            logger.message('Resolving build log path to "' + configurationBuildLog + '"');
+            logger.message(`Resolving build log path to "${configurationBuildLog}"`);
         }
 
         if (!util.checkFileExistsSync(configurationBuildLog)) {
@@ -1333,7 +1336,7 @@ export function setTargetByName(targetName: string) : void {
     currentTarget = targetName;
     let displayTarget: string = targetName ? currentTarget : "Default";
     statusBar.setTarget(displayTarget);
-    logger.message("Setting target " + displayTarget);
+    logger.message(`Setting target ${displayTarget}`);
     extension.getState().buildTarget = currentTarget;
     extension._projectOutlineProvider.updateBuildTarget(targetName);
 }
@@ -1425,7 +1428,7 @@ export async function setLaunchConfigurationByName(launchConfigurationName: stri
     }
 
     if (currentLaunchConfiguration) {
-        logger.message('Setting current launch target "' + launchConfigurationName + '"');
+        logger.message(`Setting current launch target "${launchConfigurationName}"`);
         extension.getState().launchConfiguration = launchConfigurationName;
         statusBar.setLaunchConfiguration(launchConfigurationName);
     } else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -187,7 +187,7 @@ export class MakefileToolsExtension {
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
     statusBar = ui.getUI();
-    await vscode.commands.executeCommand('setContext', "makefile:fullFeatureSet", "true");
+    await vscode.commands.executeCommand('setContext', "makefile:fullFeatureSet", false);
     extension = new MakefileToolsExtension(context);
 
     telemetry.activate();

--- a/src/make.ts
+++ b/src/make.ts
@@ -170,7 +170,7 @@ export function prepareBuildTarget(target: string): string[] {
 
     makeArgs = makeArgs.concat(configuration.getConfigurationMakeArgs());
 
-    logger.message(`Building target "${target}" with command: "` + configuration.getConfigurationMakeCommand() + " " + makeArgs.join(" ") + '"');
+    logger.message(`Building target "${target}" with command: '${configuration.getConfigurationMakeCommand()} ${makeArgs.join(" ")}'`);
     return makeArgs;
 }
 
@@ -233,7 +233,7 @@ export async function buildTarget(triggeredBy: TriggeredBy, target: string, clea
     }
 
     configAndTarget = `"${configAndTarget}"`;
-    let popupStr: string = 'Building ' + (clean ? "clean " : "") + 'the current makefile configuration ' + configAndTarget;
+    let popupStr: string = `Building ${clean ? "clean " : ""}the current makefile configuration ${configAndTarget}`;
 
     let cancelBuild: boolean = false; // when the build was cancelled by the user
 
@@ -257,7 +257,7 @@ export async function buildTarget(triggeredBy: TriggeredBy, target: string, clea
                         }
                     });
 
-                    logger.message(`Killing task ${makefileBuildTaskName}.`);
+                    logger.message(`Killing task "${makefileBuildTaskName}".`);
                     myTask?.terminate();
                 });
 
@@ -318,9 +318,11 @@ export async function buildTarget(triggeredBy: TriggeredBy, target: string, clea
 export async function doBuildTarget(progress: vscode.Progress<{}>, target: string, clearTerminalOutput: boolean): Promise<number> {
     let makeArgs: string[] = prepareBuildTarget(target);
     try {
-        let myTaskCommand: vscode.ShellQuotedString = {value: configuration.getConfigurationMakeCommand(), quoting: vscode.ShellQuoting.Strong};
+        const quotingStlye: vscode.ShellQuoting = vscode.ShellQuoting.Strong;
+        const quotingStyleName: string = "Strong";
+        let myTaskCommand: vscode.ShellQuotedString = {value: configuration.getConfigurationMakeCommand(), quoting: quotingStlye};
         let myTaskArgs: vscode.ShellQuotedString[] = makeArgs.map(arg => {
-            return {value: arg, quoting: vscode.ShellQuoting.Strong};
+            return {value: arg, quoting: quotingStlye};
         });
         let myTaskOptions: vscode.ShellExecutionOptions = {env: util.mergeEnvironment(process.env as util.EnvironmentVariables)};
         let shellExec: vscode.ShellExecution = new vscode.ShellExecution(myTaskCommand, myTaskArgs, myTaskOptions);
@@ -331,6 +333,7 @@ export async function doBuildTarget(progress: vscode.Progress<{}>, target: strin
         myTask.presentationOptions.clear = clearTerminalOutput;
         myTask.presentationOptions.showReuseMessage = true;
 
+        logger.message(`Executing task: "${myTask.name}" with quoting style "${quotingStyleName}"\n command name: ${myTaskCommand.value}\n command args ${makeArgs.join()}`, "Debug");
         await vscode.tasks.executeTask(myTask);
 
         const result: number = await(new Promise<number>(resolve => {
@@ -343,9 +346,9 @@ export async function doBuildTarget(progress: vscode.Progress<{}>, target: strin
         }));
 
         if (result !== ConfigureBuildReturnCodeTypes.success) {
-            logger.message(`Target ${target} failed to build.`);
+            logger.message(`Target "${target}" failed to build.`);
         } else {
-            logger.message(`Target ${target} built successfully.`);
+            logger.message(`Target "${target}" built successfully.`);
         }
 
         return result;
@@ -461,10 +464,10 @@ export async function generateParseContent(progress: vscode.Progress<{}>,
             }
         });
 
-        logger.messageNoCR("Generating " + (getConfigureIsInBackground() ? "in the background a new " : "") + "configuration cache with command: ");
+        logger.messageNoCR(`Generating ${getConfigureIsInBackground() ? "in the background a new " : ""}configuration cache with command: `);
     }
 
-    logger.message(configuration.getConfigurationMakeCommand() + " " + makeArgs.join(" "));
+    logger.message(`'${configuration.getConfigurationMakeCommand()} ${makeArgs.join(" ")}'`);
 
     try {
         let dryrunFile : string = forTargets ? "./targets.log" : "./dryrun.log";
@@ -475,7 +478,7 @@ export async function generateParseContent(progress: vscode.Progress<{}>,
         dryrunFile = util.resolvePathToRoot(dryrunFile);
         logger.message(`Writing the dry-run output: ${dryrunFile}`);
         const lineEnding: string = (process.platform === "win32" && process.env.MSYSTEM === undefined) ? "\r\n" : "\n";
-        util.writeFile(dryrunFile, configuration.getConfigurationMakeCommand() + " " + makeArgs.join(" ") + lineEnding);
+        util.writeFile(dryrunFile, `${configuration.getConfigurationMakeCommand()} ${makeArgs.join(" ")}${lineEnding}`);
 
         let completeOutput: string = "";
         let stderrStr: string = "";
@@ -1062,7 +1065,7 @@ async function parseLaunchConfigurations(progress: vscode.Progress<{}>, cancel: 
     let launchConfigurations: configuration.LaunchConfiguration[] = [];
 
     let onStatus: any = (status: string): void => {
-        progress.report({ increment: 1, message: status + ((recursive) ? "(recursive)" : "" + "...") });
+        progress.report({ increment: 1, message: `${status}${(recursive) ? "(recursive)" : ""}...` });
     };
 
     let onFoundLaunchConfiguration: any = (launchConfiguration: configuration.LaunchConfiguration): void => {
@@ -1077,7 +1080,7 @@ async function parseLaunchConfigurations(progress: vscode.Progress<{}>, cancel: 
         });
 
         if (launchConfigurationsStr.length === 0) {
-            logger.message("No" + (getConfigureIsClean() ? "" : " new") + " launch configurations have been detected.");
+            logger.message(`No${getConfigureIsClean() ? "" : " new"}${getConfigureIsClean() ? "" : " new"} launch configurations have been detected.`);
         } else {
             // Sort and remove duplicates that can be created in the following scenarios:
             //    - the same target binary invoked several times with the same arguments and from the same path
@@ -1088,7 +1091,7 @@ async function parseLaunchConfigurations(progress: vscode.Progress<{}>, cancel: 
             //      corresponding to the final binary, not the intermediate ones.
             launchConfigurationsStr = util.sortAndRemoveDuplicates(launchConfigurationsStr);
 
-            logger.message(`Found the following ${launchConfigurationsStr.length}` + (getConfigureIsClean() ? "" : " new") + " launch targets defined in the makefile: " + launchConfigurationsStr.join(";"));
+            logger.message(`Found the following ${launchConfigurationsStr.length}${getConfigureIsClean() ? "" : " new"} launch targets defined in the makefile: ${launchConfigurationsStr.join(";")}`);
         }
 
         if (getConfigureIsClean()) {
@@ -1125,7 +1128,7 @@ async function parseTargets(progress: vscode.Progress<{}>, cancel: vscode.Cancel
     let targets: string[] = [];
 
     let onStatus: any = (status: string): void => {
-        progress.report({ increment: 1, message: status + ((recursive) ? "(recursive)" : "") });
+        progress.report({ increment: 1, message: `${status}${(recursive) ? "(recursive)" : ""}` });
     };
 
     let onFoundTarget: any = (target: string): void => {
@@ -1135,10 +1138,10 @@ async function parseTargets(progress: vscode.Progress<{}>, cancel: vscode.Cancel
     let retc: number = await parser.parseTargets(cancel, dryRunOutput, onStatus, onFoundTarget);
     if (retc === ConfigureBuildReturnCodeTypes.success) {
         if (targets.length === 0) {
-            logger.message("No" + (getConfigureIsClean() ? "" : " new") + " build targets have been detected.");
+            logger.message(`No${getConfigureIsClean() ? "" : " new"} build targets have been detected.`);
         } else {
             targets = targets.sort();
-            logger.message(`Found the following ${targets.length}` + (getConfigureIsClean() ? "" : " new") + " build targets defined in the makefile: " + targets.join(";"));
+            logger.message(`Found the following ${targets.length}${getConfigureIsClean() ? "" : " new"} build targets defined in the makefile: ${targets.join(";")}`);
         }
 
         if (getConfigureIsClean()) {
@@ -1171,10 +1174,10 @@ async function updateProvider(progress: vscode.Progress<{}>, cancel: vscode.Canc
     }
 
     let startTime: number = Date.now();
-    logger.message("Updating the CppTools IntelliSense Configuration Provider." + ((recursive) ? "(recursive)" : ""));
+    logger.message(`Updating the CppTools IntelliSense Configuration Provider.${(recursive) ? "(recursive)" : ""}`);
 
     let onStatus: any = (status: string): void => {
-        progress.report({ increment: 1, message: status + ((recursive) ? "(recursive)" : "" + "...") });
+        progress.report({ increment: 1, message: `${status}${(recursive) ? "(recursive)" : ""} ...` });
     };
 
     let onFoundCustomConfigProviderItem: any = (customConfigProviderItem: parser.CustomConfigProviderItem): void => {
@@ -1223,7 +1226,7 @@ export async function preprocessDryRun(progress: vscode.Progress<{}>, cancel: vs
     }
 
     let onStatus: any = (status: string): void => {
-        progress.report({ increment: 1, message: status + ((recursive) ? "(recursive)" : "" + "...") });
+        progress.report({ increment: 1, message: `${status}${(recursive) ? "(recursive)" : ""} ...` });
     };
 
     return parser.preprocessDryRunOutput(cancel, dryrunOutput, onStatus);

--- a/src/make.ts
+++ b/src/make.ts
@@ -519,7 +519,7 @@ export async function generateParseContent(progress: vscode.Progress<{}>,
         }, 5 * 1000);
 
         // The dry-run analysis should operate on english.
-        const result: util.SpawnProcessResult = await util.spawnChildProcess(configuration.getConfigurationMakeCommand(), makeArgs, util.getWorkspaceRoot(), true, stdout, stderr);
+        const result: util.SpawnProcessResult = await util.spawnChildProcess(configuration.getConfigurationMakeCommand(), makeArgs, util.getWorkspaceRoot(), true, true, stdout, stderr);
         clearInterval(timeout);
         let elapsedTime: number = util.elapsedTimeSince(startTime);
         logger.message(`Generating dry-run elapsed time: ${elapsedTime}`);
@@ -699,7 +699,7 @@ export async function runPreConfigureScript(progress: vscode.Progress<{}>, scrip
         };
 
         // The preconfigure invocation should use the system locale.
-        const result: util.SpawnProcessResult = await util.spawnChildProcess(runCommand, scriptArgs, util.getWorkspaceRoot(), false, stdout, stderr);
+        const result: util.SpawnProcessResult = await util.spawnChildProcess(runCommand, scriptArgs, util.getWorkspaceRoot(), false, false, stdout, stderr);
         if (result.returnCode === ConfigureBuildReturnCodeTypes.success) {
             if (someErr) {
                 // Depending how the preconfigure scripts (and any inner called sub-scripts) are written,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -492,12 +492,12 @@ async function parseAnySwitchFromToolArguments(args: string, excludeArgs: string
         };
 
         let stderr: any = (result: string): void => {
-            logger.message(`Error while running the compiler args parser script '${parseCompilerArgsScriptFile}'` +
+            logger.message(`Error while running the compiler args parser script '${parseCompilerArgsScriptFile}' ` +
                 `for regions ("${compilerArgRegions})": "${result}"`, "Normal");
         };
 
         // Running the compiler arguments parsing script can use the system locale.
-        const result: util.SpawnProcessResult = await util.spawnChildProcess(runCommand, scriptArgs, util.getWorkspaceRoot(), false, stdout, stderr);
+        const result: util.SpawnProcessResult = await util.spawnChildProcess(runCommand, scriptArgs, util.getWorkspaceRoot(), false, false, stdout, stderr);
         if (result.returnCode !== 0) {
             logger.message(`The compiler args parser script '${parseCompilerArgsScriptFile}' failed with error code ${result.returnCode} for regions (${compilerArgRegions})`, "Normal");
         }

--- a/src/test/fakeSuite/Repros/.vscode/settings.json
+++ b/src/test/fakeSuite/Repros/.vscode/settings.json
@@ -7,6 +7,18 @@
     "makefile.configureOnOpen": false,
     "makefile.configurations": [
         {
+            "name": "test-make-f",
+            "makePath": "./make",
+            "buildLog": "./doesnt_exist.log",
+            "makeArgs": ["-f", "./SubDir/makefile with space"]
+        },
+        {
+            "name": "test-make-C",
+            "makePath": "./make",
+            "buildLog": "./doesnt_exist.log",
+            "makeArgs": ["-C", "./SubDir with space/"]
+        },
+        {
             "name": "complex_escaped_quotes",
             "buildLog": "./complex_escaped_quotes_dryrun.log"
         },

--- a/src/test/fakeSuite/Repros/.vscode/settings.json
+++ b/src/test/fakeSuite/Repros/.vscode/settings.json
@@ -8,13 +8,13 @@
     "makefile.configurations": [
         {
             "name": "test-make-f",
-            "makePath": "./make",
+            "makePath": "./doesnt/exist/make",
             "buildLog": "./doesnt_exist.log",
             "makeArgs": ["-f", "./SubDir/makefile with space"]
         },
         {
             "name": "test-make-C",
-            "makePath": "./make",
+            "makePath": "./doesnt/exist/make",
             "buildLog": "./doesnt_exist.log",
             "makeArgs": ["-C", "./SubDir with space/"]
         },

--- a/src/test/fakeSuite/Repros/8cc_linux_baseline.out
+++ b/src/test/fakeSuite/Repros/8cc_linux_baseline.out
@@ -2,9 +2,9 @@ Pre-configuring...
 Script: "{REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros/.vscode/preconfigure_nonwin.sh"
 The pre-configure succeeded.
 Setting configuration - 8cc_linux
-Found build log path setting "./8cc_linux_dryrun.log" defined for configuration "8cc_linux
+Found build log path setting "./8cc_linux_dryrun.log" defined for configuration "8cc_linux"
 Resolving build log path to "{REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros/8cc_linux_dryrun.log"
-Deduced command 'c:/some/other/fake/path ' for configuration 8cc_linux
+Deduced command 'c:/some/other/fake/path ' for configuration "8cc_linux"
 Saving opened files before build.
 Loading configurations from cache is not necessary.
 Preprocessing: "{REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros/8cc_linux_dryrun.log"
@@ -205,4 +205,4 @@ Created the following debug config:
    symbolSearchPath = undefined
 Running command '"{REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros/8cc" ' in the terminal from location '{REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros'
 Setting target all
-Building target "all" with command: "c:/some/other/fake/path all"
+Building target "all" with command: 'c:/some/other/fake/path all'

--- a/src/test/fakeSuite/Repros/8cc_mingw_baseline.out
+++ b/src/test/fakeSuite/Repros/8cc_mingw_baseline.out
@@ -13,7 +13,7 @@ Sending Workspace Browse Configuration: -----------------------------------
 ----------------------------------------------------------------------------
 Found the following configurations defined in makefile.configurations setting: InterestingSmallMakefile_windows_configDebug;InterestingSmallMakefile_windows_configRelSize;InterestingSmallMakefile_windows_configRelSpeed;8cc_linux;8cc_mingw;Fido_linux;Fido_mingw;tinyvm_linux_pedantic;tinyvm_mingw_pedantic
 Setting configuration - 8cc_mingw
-Found build log path setting "./8cc_mingw_dryrun.log" defined for configuration "8cc_mingw
+Found build log path setting "./8cc_mingw_dryrun.log" defined for configuration "8cc_mingw"
 Resolving build log path to "{REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\8cc_mingw_dryrun.log"
 Parsing the provided build log "{REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\8cc_mingw_dryrun.log" for IntelliSense integration with CppTools...
 Updating the CppTools IntelliSense Configuration Provider.

--- a/src/test/fakeSuite/Repros/Fido_linux_baseline.out
+++ b/src/test/fakeSuite/Repros/Fido_linux_baseline.out
@@ -2,9 +2,9 @@ Pre-configuring...
 Script: "{REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros/.vscode/preconfigure_nonwin.sh"
 The pre-configure succeeded.
 Setting configuration - Fido_linux
-Found build log path setting "./Fido_linux_dryrun.log" defined for configuration "Fido_linux
+Found build log path setting "./Fido_linux_dryrun.log" defined for configuration "Fido_linux"
 Resolving build log path to "{REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros/Fido_linux_dryrun.log"
-Deduced command 'c:/some/other/fake/path ' for configuration Fido_linux
+Deduced command 'c:/some/other/fake/path ' for configuration "Fido_linux"
 Saving opened files before build.
 Loading configurations from cache is not necessary.
 Preprocessing: "{REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros/Fido_linux_dryrun.log"
@@ -225,4 +225,4 @@ Created the following debug config:
    symbolSearchPath = undefined
 Running command '"{REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros/bin/foo.o" ' in the terminal from location '{REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros'
 Setting target bin/foo.o
-Building target "bin/foo.o" with command: "c:/some/other/fake/path bin/foo.o"
+Building target "bin/foo.o" with command: 'c:/some/other/fake/path bin/foo.o'

--- a/src/test/fakeSuite/Repros/Fido_mingw_baseline.out
+++ b/src/test/fakeSuite/Repros/Fido_mingw_baseline.out
@@ -1,5 +1,5 @@
 Setting configuration - Fido_mingw
-Found build log path setting "./Fido_mingw_dryrun.log" defined for configuration "Fido_mingw
+Found build log path setting "./Fido_mingw_dryrun.log" defined for configuration "Fido_mingw"
 Resolving build log path to "{REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\Fido_mingw_dryrun.log"
 Parsing the provided build log "{REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\Fido_mingw_dryrun.log" for IntelliSense integration with CppTools...
 Updating the CppTools IntelliSense Configuration Provider.

--- a/src/test/fakeSuite/Repros/InterestingSmallMakefile_windows_baseline.out
+++ b/src/test/fakeSuite/Repros/InterestingSmallMakefile_windows_baseline.out
@@ -4,9 +4,9 @@ Script: "{REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\.vscode\preconfi
 {REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros>call "{REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\.vscode\preconfigure.bat" 
 The pre-configure succeeded.
 Setting configuration - InterestingSmallMakefile_windows_configDebug
-Found build log path setting "./InterestingSmallMakefile_windows_dryrunDebug.log" defined for configuration "InterestingSmallMakefile_windows_configDebug
+Found build log path setting "./InterestingSmallMakefile_windows_dryrunDebug.log" defined for configuration "InterestingSmallMakefile_windows_configDebug"
 Resolving build log path to "{REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\InterestingSmallMakefile_windows_dryrunDebug.log"
-Deduced command 'c:\some\other\fake\path.exe ' for configuration InterestingSmallMakefile_windows_configDebug
+Deduced command 'c:\some\other\fake\path.exe ' for configuration "InterestingSmallMakefile_windows_configDebug"
 Saving opened files before build.
 Loading configurations from cache is not necessary.
 Preprocessing: "{REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\InterestingSmallMakefile_windows_dryrunDebug.log"
@@ -239,10 +239,10 @@ Created the following debug config:
    symbolSearchPath = undefined
 Running command '"{REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\bin\InterestingSmallMakefile\arch2\Debug\main.exe" ' in the terminal from location '{REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros'
 Setting configuration - InterestingSmallMakefile_windows_configRelSize
-Found build log path setting "./InterestingSmallMakefile_windows_dryrunRelSize.log" defined for configuration "InterestingSmallMakefile_windows_configRelSize
+Found build log path setting "./InterestingSmallMakefile_windows_dryrunRelSize.log" defined for configuration "InterestingSmallMakefile_windows_configRelSize"
 Resolving build log path to "{REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\InterestingSmallMakefile_windows_dryrunRelSize.log"
-Deduced command 'c:\some\other\fake\make.exe OPT=RelSize' for configuration InterestingSmallMakefile_windows_configRelSize
+Deduced command 'c:\some\other\fake\make.exe OPT=RelSize' for configuration "InterestingSmallMakefile_windows_configRelSize"
 Setting configuration - InterestingSmallMakefile_windows_configRelSpeed
-Deduced command 'c:\fake\path\make.exe OPT=RelSpeed' for configuration InterestingSmallMakefile_windows_configRelSpeed
+Deduced command 'c:\fake\path\make.exe OPT=RelSpeed' for configuration "InterestingSmallMakefile_windows_configRelSpeed"
 Setting target Execute_Arch3
-Building target "Execute_Arch3" with command: "c:\fake\path\make.exe Execute_Arch3 OPT=RelSpeed"
+Building target "Execute_Arch3" with command: 'c:\fake\path\make.exe Execute_Arch3 OPT=RelSpeed'

--- a/src/test/fakeSuite/Repros/complex_escaped_quotes_baseline.out
+++ b/src/test/fakeSuite/Repros/complex_escaped_quotes_baseline.out
@@ -4,9 +4,9 @@ Script: "{REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\.vscode\preconfi
 {REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros>call "{REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\.vscode\preconfigure.bat" 
 The pre-configure succeeded.
 Setting configuration - complex_escaped_quotes
-Found build log path setting "./complex_escaped_quotes_dryrun.log" defined for configuration "complex_escaped_quotes
+Found build log path setting "./complex_escaped_quotes_dryrun.log" defined for configuration "complex_escaped_quotes"
 Resolving build log path to "{REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\complex_escaped_quotes_dryrun.log"
-Deduced command 'c:\some\other\fake\path.exe ' for configuration complex_escaped_quotes
+Deduced command 'c:\some\other\fake\path.exe ' for configuration "complex_escaped_quotes"
 Saving opened files before build.
 Preprocessing: "{REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\complex_escaped_quotes_dryrun.log"
 Preprocess elapsed time: 0

--- a/src/test/fakeSuite/Repros/complex_escaped_quotes_nonWin_baseline.out
+++ b/src/test/fakeSuite/Repros/complex_escaped_quotes_nonWin_baseline.out
@@ -2,9 +2,9 @@ Pre-configuring...
 Script: "{REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros/.vscode/preconfigure_nonwin.sh"
 The pre-configure succeeded.
 Setting configuration - complex_escaped_quotes
-Found build log path setting "./complex_escaped_quotes_dryrun.log" defined for configuration "complex_escaped_quotes
+Found build log path setting "./complex_escaped_quotes_dryrun.log" defined for configuration "complex_escaped_quotes"
 Resolving build log path to "{REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros/complex_escaped_quotes_dryrun.log"
-Deduced command 'c:/some/other/fake/path ' for configuration complex_escaped_quotes
+Deduced command 'c:/some/other/fake/path ' for configuration "complex_escaped_quotes"
 Saving opened files before build.
 Preprocessing: "{REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros/complex_escaped_quotes_dryrun.log"
 Preprocess elapsed time: 0

--- a/src/test/fakeSuite/Repros/complex_escaped_quotes_winOnly_baseline.out
+++ b/src/test/fakeSuite/Repros/complex_escaped_quotes_winOnly_baseline.out
@@ -4,9 +4,9 @@ Script: "{REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\.vscode\preconfi
 {REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros>call "{REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\.vscode\preconfigure.bat" 
 The pre-configure succeeded.
 Setting configuration - complex_escaped_quotes_winOnly
-Found build log path setting "./complex_escaped_quotes_winOnly_dryrun.log" defined for configuration "complex_escaped_quotes_winOnly
+Found build log path setting "./complex_escaped_quotes_winOnly_dryrun.log" defined for configuration "complex_escaped_quotes_winOnly"
 Resolving build log path to "{REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\complex_escaped_quotes_winOnly_dryrun.log"
-Deduced command 'c:\some\other\fake\path.exe ' for configuration complex_escaped_quotes_winOnly
+Deduced command 'c:\some\other\fake\path.exe ' for configuration "complex_escaped_quotes_winOnly"
 Saving opened files before build.
 Loading configurations from cache is not necessary.
 Preprocessing: "{REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\complex_escaped_quotes_winOnly_dryrun.log"

--- a/src/test/fakeSuite/Repros/test_real_make_nonWin_baseline.out
+++ b/src/test/fakeSuite/Repros/test_real_make_nonWin_baseline.out
@@ -1,0 +1,81 @@
+Setting configuration - test-make-f
+Found build log path setting "./doesnt_exist.log" defined for configuration "test-make-f"
+Resolving build log path to "{REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros/doesnt_exist.log"
+Build log not found. Remove the build log setting or provide a build log file on disk at the given location.
+Deduced command 'doesnt/exist/make -f ./SubDir/makefile with space' for configuration "test-make-f"
+Make was not found on disk at the location provided via makefile.makePath or makefile.configurations[].makePath.
+Saving opened files before build.
+Loading configurations from cache is not necessary.
+Generating configuration cache with command: 'doesnt/exist/make -f ./SubDir/makefile with space --dry-run --always-make --keep-going --print-directory'
+Writing the dry-run output: {REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros/.vscode/dryrun.log
+Spawning child process with:
+ process name: doesnt/exist/make
+ process args: -f,"./SubDir/makefile with space",--dry-run,--always-make,--keep-going,--print-directory
+ working directory: {REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros
+ shell type: default
+Generating dry-run elapsed time: 0
+The make dry-run command failed.
+IntelliSense may work only partially or not at all.
+/bin/sh: 1: doesnt/exist/make: not found
+ 
+
+You can see the detailed dry-run output at {REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros/.vscode/dryrun.log
+Make sure that the extension is invoking the same make command as in your development prompt environment.
+You may need to define or tweak a custom makefile configuration in settings via 'makefile.configurations' like described here: [link]
+Also make sure your code base does not have any known issues with the dry-run switches used by this extension (makefile.dryrunSwitches).
+If you are not able to fix the dry-run, open a GitHub issue in Makefile Tools repo: https://github.com/microsoft/vscode-makefile-tools/issues
+Preprocessing: "{REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros/.vscode/dryrun.log"
+Preprocess elapsed time: 0
+Parsing for IntelliSense.
+Updating the CppTools IntelliSense Configuration Provider.
+Parsing dry-run output for CppTools Custom Configuration Provider.
+Sending Workspace Browse Configuration: -----------------------------------
+    Browse Path: 
+    Standard: undefined
+    Compiler Path: undefined
+    Compiler Arguments: 
+----------------------------------------------------------------------------
+Parsing for IntelliSense elapsed time: 0
+Parsing for launch targets.
+No launch configurations have been detected.
+Complete list of launch targets: 
+Parsing for launch targets elapsed time: 0
+Generating parse content for build targets.
+Generating targets information with command: 'doesnt/exist/make all -f ./SubDir/makefile with space --print-data-base --no-builtin-variables --no-builtin-rules --question'
+Writing the dry-run output: {REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros/.vscode/targets.log
+Spawning child process with:
+ process name: doesnt/exist/make
+ process args: all,-f,"./SubDir/makefile with space",--print-data-base,--no-builtin-variables,--no-builtin-rules,--question
+ working directory: {REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros
+ shell type: default
+Generating dry-run elapsed time: 0
+Parsing for build targets from: "{REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros/.vscode/targets.log"
+No build targets have been detected.
+Complete list of build targets: 
+Parsing build targets elapsed time: 0
+Configure finished. The status for all the subphases that ran:
+generateParseContent: return code = 127, elapsed time = 0
+preprocessParseContent: return code = 0, elapsed time = 0
+parseIntelliSense: return code = 0, elapsed time = 0
+parseLaunch: return code = 0, elapsed time = 0
+dryrunTargets: return code = 127, elapsed time = 0
+parseTargets: return code = 0, elapsed time = 0
+Configure succeeded.
+Configure elapsed time: 0
+Setting configuration - test-make-C
+Found build log path setting "./doesnt_exist.log" defined for configuration "test-make-C"
+Resolving build log path to "{REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros/doesnt_exist.log"
+Build log not found. Remove the build log setting or provide a build log file on disk at the given location.
+Deduced command 'doesnt/exist/make -C ./SubDir with space/' for configuration "test-make-C"
+Make was not found on disk at the location provided via makefile.makePath or makefile.configurations[].makePath.
+Saving opened files before build.
+Building target "clean" with command: 'doesnt/exist/make clean -C ./SubDir with space/'
+Executing task: "Makefile Tools Build Task" with quoting style "Strong"
+ command name: doesnt/exist/make
+ command args clean,-C,./SubDir with space/
+Target "clean" failed to build.
+Building target "all" with command: 'doesnt/exist/make all -C ./SubDir with space/'
+Executing task: "Makefile Tools Build Task" with quoting style "Strong"
+ command name: doesnt/exist/make
+ command args all,-C,./SubDir with space/
+Target "all" failed to build.

--- a/src/test/fakeSuite/Repros/test_real_make_windows_baseline.out
+++ b/src/test/fakeSuite/Repros/test_real_make_windows_baseline.out
@@ -1,0 +1,82 @@
+Setting configuration - test-make-f
+Found build log path setting "./doesnt_exist.log" defined for configuration "test-make-f"
+Resolving build log path to "{REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\doesnt_exist.log"
+Build log not found. Remove the build log setting or provide a build log file on disk at the given location.
+Deduced command 'make.exe -f ./SubDir/makefile with space' for configuration "test-make-f"
+Make was not found on disk at the location provided via makefile.makePath or makefile.configurations[].makePath.
+Saving opened files before build.
+Loading configurations from cache is not necessary.
+Generating configuration cache with command: 'make.exe -f ./SubDir/makefile with space --dry-run --always-make --keep-going --print-directory'
+Writing the dry-run output: {REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\.vscode\dryrun.log
+Spawning child process with:
+ process name: make.exe
+ process args: -f,"./SubDir/makefile with space",--dry-run,--always-make,--keep-going,--print-directory
+ working directory: {REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros
+ shell type: default
+Generating dry-run elapsed time: 0
+The make dry-run command failed.
+IntelliSense may work only partially or not at all.
+'make.exe' is not recognized as an internal or external command,
+operable program or batch file.
+ 
+
+You can see the detailed dry-run output at {REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\.vscode\dryrun.log
+Make sure that the extension is invoking the same make command as in your development prompt environment.
+You may need to define or tweak a custom makefile configuration in settings via 'makefile.configurations' like described here: [link]
+Also make sure your code base does not have any known issues with the dry-run switches used by this extension (makefile.dryrunSwitches).
+If you are not able to fix the dry-run, open a GitHub issue in Makefile Tools repo: https://github.com/microsoft/vscode-makefile-tools/issues
+Preprocessing: "{REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\.vscode\dryrun.log"
+Preprocess elapsed time: 0
+Parsing for IntelliSense.
+Updating the CppTools IntelliSense Configuration Provider.
+Parsing dry-run output for CppTools Custom Configuration Provider.
+Sending Workspace Browse Configuration: -----------------------------------
+    Browse Path: 
+    Standard: undefined
+    Compiler Path: undefined
+    Compiler Arguments: 
+----------------------------------------------------------------------------
+Parsing for IntelliSense elapsed time: 0
+Parsing for launch targets.
+No launch configurations have been detected.
+Complete list of launch targets: 
+Parsing for launch targets elapsed time: 0
+Generating parse content for build targets.
+Generating targets information with command: 'make.exe all -f ./SubDir/makefile with space --print-data-base --no-builtin-variables --no-builtin-rules --question'
+Writing the dry-run output: {REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\.vscode\targets.log
+Spawning child process with:
+ process name: make.exe
+ process args: all,-f,"./SubDir/makefile with space",--print-data-base,--no-builtin-variables,--no-builtin-rules,--question
+ working directory: {REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros
+ shell type: default
+Generating dry-run elapsed time: 0
+Parsing for build targets from: "{REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\.vscode\targets.log"
+No build targets have been detected.
+Complete list of build targets: 
+Parsing build targets elapsed time: 0
+Configure finished. The status for all the subphases that ran:
+generateParseContent: return code = 1, elapsed time = 0
+preprocessParseContent: return code = 0, elapsed time = 0
+parseIntelliSense: return code = 0, elapsed time = 0
+parseLaunch: return code = 0, elapsed time = 0
+dryrunTargets: return code = 1, elapsed time = 0
+parseTargets: return code = 0, elapsed time = 0
+Configure succeeded.
+Configure elapsed time: 0
+Setting configuration - test-make-C
+Found build log path setting "./doesnt_exist.log" defined for configuration "test-make-C"
+Resolving build log path to "{REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\doesnt_exist.log"
+Build log not found. Remove the build log setting or provide a build log file on disk at the given location.
+Deduced command 'make.exe -C ./SubDir with space/' for configuration "test-make-C"
+Make was not found on disk at the location provided via makefile.makePath or makefile.configurations[].makePath.
+Saving opened files before build.
+Building target "clean" with command: 'make.exe clean -C ./SubDir with space/'
+Executing task: "Makefile Tools Build Task" with quoting style "Strong"
+ command name: make.exe
+ command args clean,-C,./SubDir with space/
+Target "clean" failed to build.
+Building target "all" with command: 'make.exe all -C ./SubDir with space/'
+Executing task: "Makefile Tools Build Task" with quoting style "Strong"
+ command name: make.exe
+ command args all,-C,./SubDir with space/
+Target "all" failed to build.

--- a/src/test/fakeSuite/Repros/test_real_make_windows_baseline.out
+++ b/src/test/fakeSuite/Repros/test_real_make_windows_baseline.out
@@ -2,22 +2,21 @@ Setting configuration - test-make-f
 Found build log path setting "./doesnt_exist.log" defined for configuration "test-make-f"
 Resolving build log path to "{REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\doesnt_exist.log"
 Build log not found. Remove the build log setting or provide a build log file on disk at the given location.
-Deduced command 'make.exe -f ./SubDir/makefile with space' for configuration "test-make-f"
+Deduced command 'doesnt\exist\make.exe -f ./SubDir/makefile with space' for configuration "test-make-f"
 Make was not found on disk at the location provided via makefile.makePath or makefile.configurations[].makePath.
 Saving opened files before build.
 Loading configurations from cache is not necessary.
-Generating configuration cache with command: 'make.exe -f ./SubDir/makefile with space --dry-run --always-make --keep-going --print-directory'
+Generating configuration cache with command: 'doesnt\exist\make.exe -f ./SubDir/makefile with space --dry-run --always-make --keep-going --print-directory'
 Writing the dry-run output: {REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\.vscode\dryrun.log
 Spawning child process with:
- process name: make.exe
+ process name: doesnt\exist\make.exe
  process args: -f,"./SubDir/makefile with space",--dry-run,--always-make,--keep-going,--print-directory
  working directory: {REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros
  shell type: default
 Generating dry-run elapsed time: 0
 The make dry-run command failed.
 IntelliSense may work only partially or not at all.
-'make.exe' is not recognized as an internal or external command,
-operable program or batch file.
+The system cannot find the path specified.
  
 
 You can see the detailed dry-run output at {REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\.vscode\dryrun.log
@@ -42,10 +41,10 @@ No launch configurations have been detected.
 Complete list of launch targets: 
 Parsing for launch targets elapsed time: 0
 Generating parse content for build targets.
-Generating targets information with command: 'make.exe all -f ./SubDir/makefile with space --print-data-base --no-builtin-variables --no-builtin-rules --question'
+Generating targets information with command: 'doesnt\exist\make.exe all -f ./SubDir/makefile with space --print-data-base --no-builtin-variables --no-builtin-rules --question'
 Writing the dry-run output: {REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\.vscode\targets.log
 Spawning child process with:
- process name: make.exe
+ process name: doesnt\exist\make.exe
  process args: all,-f,"./SubDir/makefile with space",--print-data-base,--no-builtin-variables,--no-builtin-rules,--question
  working directory: {REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros
  shell type: default
@@ -67,16 +66,16 @@ Setting configuration - test-make-C
 Found build log path setting "./doesnt_exist.log" defined for configuration "test-make-C"
 Resolving build log path to "{REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\doesnt_exist.log"
 Build log not found. Remove the build log setting or provide a build log file on disk at the given location.
-Deduced command 'make.exe -C ./SubDir with space/' for configuration "test-make-C"
+Deduced command 'doesnt\exist\make.exe -C ./SubDir with space/' for configuration "test-make-C"
 Make was not found on disk at the location provided via makefile.makePath or makefile.configurations[].makePath.
 Saving opened files before build.
-Building target "clean" with command: 'make.exe clean -C ./SubDir with space/'
+Building target "clean" with command: 'doesnt\exist\make.exe clean -C ./SubDir with space/'
 Executing task: "Makefile Tools Build Task" with quoting style "Strong"
- command name: make.exe
+ command name: doesnt\exist\make.exe
  command args clean,-C,./SubDir with space/
 Target "clean" failed to build.
-Building target "all" with command: 'make.exe all -C ./SubDir with space/'
+Building target "all" with command: 'doesnt\exist\make.exe all -C ./SubDir with space/'
 Executing task: "Makefile Tools Build Task" with quoting style "Strong"
- command name: make.exe
+ command name: doesnt\exist\make.exe
  command args all,-C,./SubDir with space/
 Target "all" failed to build.

--- a/src/test/fakeSuite/Repros/tinyvm_linux_baseline.out
+++ b/src/test/fakeSuite/Repros/tinyvm_linux_baseline.out
@@ -2,9 +2,9 @@ Pre-configuring...
 Script: "{REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros/.vscode/preconfigure_nonwin.sh"
 The pre-configure succeeded.
 Setting configuration - tinyvm_linux_pedantic
-Found build log path setting "./tinyvm_linux_dryrunPedantic.log" defined for configuration "tinyvm_linux_pedantic
+Found build log path setting "./tinyvm_linux_dryrunPedantic.log" defined for configuration "tinyvm_linux_pedantic"
 Resolving build log path to "{REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros/tinyvm_linux_dryrunPedantic.log"
-Deduced command 'c:/some/other/fake/make PEDANTIC=yes' for configuration tinyvm_linux_pedantic
+Deduced command 'c:/some/other/fake/make PEDANTIC=yes' for configuration "tinyvm_linux_pedantic"
 Saving opened files before build.
 Loading configurations from cache is not necessary.
 Preprocessing: "{REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros/tinyvm_linux_dryrunPedantic.log"
@@ -169,4 +169,4 @@ Created the following debug config:
    symbolSearchPath = undefined
 Running command '"{REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros/bin/tvmi" ' in the terminal from location '{REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros'
 Setting target tvmi
-Building target "tvmi" with command: "c:/some/other/fake/make tvmi PEDANTIC=yes"
+Building target "tvmi" with command: 'c:/some/other/fake/make tvmi PEDANTIC=yes'

--- a/src/test/fakeSuite/Repros/tinyvm_mingw_baseline.out
+++ b/src/test/fakeSuite/Repros/tinyvm_mingw_baseline.out
@@ -1,6 +1,6 @@
 Setting configuration - tinyvm_mingw_pedantic
-Found command 'c:\some\other\fake\make PEDANTIC=yes' for configuration tinyvm_mingw_pedantic
-Found build log path setting "./tinyvm_mingw_dryrunPedantic.log" defined for configuration "tinyvm_mingw_pedantic
+Found command 'c:\some\other\fake\make PEDANTIC=yes' for configuration "tinyvm_mingw_pedantic"
+Found build log path setting "./tinyvm_mingw_dryrunPedantic.log" defined for configuration "tinyvm_mingw_pedantic"
 Resolving build log path to "{REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\tinyvm_mingw_dryrunPedantic.log"
 Parsing the provided build log "{REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\tinyvm_mingw_dryrunPedantic.log" for IntelliSense integration with CppTools...
 Updating the CppTools IntelliSense Configuration Provider.

--- a/src/util.ts
+++ b/src/util.ts
@@ -274,6 +274,11 @@ export function spawnChildProcess(
         let qArgs: string[] = ensureQuoted ? args.map(arg => {
             return quoteStringIfNeeded(arg);
         }) : args;
+
+        if (ensureQuoted) {
+           logger.message(`Spawning child process with:\n process name: ${qProcessName}\n process args: ${qArgs}\n working directory: ${workingDirectory}\n shell type: ${shellType || "default"}`, "Debug");
+        }
+
         const child: child_process.ChildProcess = child_process.spawn(qProcessName, qArgs,
                                                                       { cwd: workingDirectory, shell: shellType || true, env: finalEnvironment });
         make.setCurPID(child.pid);


### PR DESCRIPTION
- Honor the "terminal.integrated.automationShell" setting when spawning make for configure. [#233](https://github.com/microsoft/vscode-makefile-tools/issues/233)
- Remove the "build" button icon from other UIs than the main Makefile Tools panel. [#245](https://github.com/microsoft/vscode-makefile-tools/issues/245)
- The build task fails for projects using -f or -C (makefile not in root) because of quoting. [#249](https://github.com/microsoft/vscode-makefile-tools/issues/249)
- Fix activation for makefiles below the root. [#248](https://github.com/microsoft/vscode-makefile-tools/issues/248)

Duplicates of 248: https://github.com/microsoft/vscode-makefile-tools/issues/250 and https://github.com/microsoft/vscode-makefile-tools/issues/246
