### PR TITLE
Improve the configuration title

### DIFF
--- a/package.json
+++ b/package.json
@@ -216,7 +216,7 @@
           ],
         "configuration": {
             "type": "object",
-            "title": "makefile",
+            "title": "Makefile Tools",
             "properties": {
                 "makefile.configurations": {
                     "type": "array",


### PR DESCRIPTION
When looking at the settings UI in VS Code, there is an inconsistency in the labelling of the Makefile Tools extension. It currently labeled `makefile` whereas other extensions use Title Casing and usually list the name of the extension. I think we should do the same.

### Before:
  ![image](https://user-images.githubusercontent.com/12818240/147615396-e0e60aaa-fe8f-44a1-96f6-9486de35049d.png)

### After:
  ![image](https://user-images.githubusercontent.com/12818240/147615423-189941b9-bdc2-4d04-beb4-a0baca9ca7ad.png)
