### PR TITLE
Fix issue with missing translations

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -206,12 +206,11 @@ const generatedSrcLocBundle = () => {
     return tsProject.src()
         .pipe(sourcemaps.init())
         .pipe(tsProject()).js
-        .pipe(nls.createMetaDataFiles())
+        .pipe(nls.rewriteLocalizeCalls())
         .pipe(nls.createAdditionalLanguageFiles(languages, "i18n"))
-        .pipe(nls.bundleMetaDataFiles('ms-vscode.makefile-tools', 'dist'))
+        .pipe(nls.bundleMetaDataFiles('ms-vscode.makefile-tools', 'out'))
         .pipe(nls.bundleLanguageFiles())
-        .pipe(filter(['**/nls.bundle.*.json', '**/nls.metadata.header.json', '**/nls.metadata.json']))
-        .pipe(gulp.dest('dist'));
+        .pipe(gulp.dest('out'));
 };
 
 const generateLocalizedJsonSchemaFiles = () => {

--- a/package.json
+++ b/package.json
@@ -688,7 +688,7 @@
     "scripts": {
         "vscode:prepublish": "yarn compile-production",
         "compile": "yarn install && tsc -p ./",
-        "compile-production": "yarn install && yarn run translations-generate && yarn run compile",
+        "compile-production": "yarn install && yarn run translations-generate",
         "translations-export": "gulp translations-export",
         "translations-generate": "gulp translations-generate",
         "translations-import": "gulp translations-import",


### PR DESCRIPTION
The gulp scripts copied from cpptools and CMake Tools were set up to work with webpack.  Makefile Tools does not use webpack, so some changes were needed.

vscode-nls depends on a "rewrite" of the calls to `localize` by vscode-nls-dev.  (This improves performance, as it switches to using indexes to look up loc strings instead of using key names.  I suspect there are other reasons it's needed.).  That rewrite was occurring for cpptools and CMake Tools during the webpack stage.  This change for Makefile Tools performs that rewrite explicitly in the gulp build task.

Because the rewrite step implicity requires converting the TypeScript code to JavaScript, the call to `tsc -p ./` was superfluous when running `compile-production`.  (It would actually replace the rewritten js files with non-rewritten contents).

Also, fixed the output location of the loc bundles.  `dist` was the location files were output for webpack.  Instead, I switched this to out, which is where it writes js files when building with `tsc`.

This fixed the issue for me when copying the files into an installed extension directory.  @andreeis , could you try building this into a VSIX to validate it fixes the issue?