### PR TITLE
Proposed fix for microsoft/vscode-makefile-tools/issues/290

### DIFF
--- a/package.json
+++ b/package.json
@@ -505,7 +505,7 @@
                     "description": "%makefile-tools.configuration.makefile.compileCommandsPath.description%",
                     "scope": "resource"
                 },
-                "makefile.optionalFeatures": {
+                "makefile.panel.visibility": {
                     "type": "object",
                     "default": null,
                     "properties": {

--- a/package.json
+++ b/package.json
@@ -502,6 +502,12 @@
                     "default": null,
                     "description": "%makefile-tools.configuration.makefile.compileCommandsPath.description%",
                     "scope": "resource"
+                },
+                "makefile.enableLocalDebugRun": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "%makefile-tools.configuration.makefile.enableLocalDebugRun.description%",
+                    "scope": "resource"
                 }
             }
         },
@@ -548,11 +554,11 @@
                 },
                 {
                     "command": "makefile.launchDebug",
-                    "when": "makefile:fullFeatureSet"
+                    "when": "makefile:localFeatureSet"
                 },
                 {
                     "command": "makefile.launchRun",
-                    "when": "makefile:fullFeatureSet"
+                    "when": "makefile:localFeatureSet"
                 },
                 {
                     "command": "makefile.setBuildConfiguration",
@@ -564,7 +570,7 @@
                 },
                 {
                     "command": "makefile.setLaunchConfiguration",
-                    "when": "makefile:fullFeatureSet"
+                    "when": "makefile:localFeatureSet"
                 },
                 {
                     "command": "makefile.outline.preConfigure",
@@ -580,11 +586,11 @@
                 },
                 {
                     "command": "makefile.outline.launchDebug",
-                    "when": "makefile:fullFeatureSet"
+                    "when": "makefile:localFeatureSet"
                 },
                 {
                     "command": "makefile.outline.launchRun",
-                    "when": "makefile:fullFeatureSet"
+                    "when": "makefile:localFeatureSet"
                 },
                 {
                     "command": "makefile.outline.setBuildConfiguration",
@@ -596,7 +602,7 @@
                 },
                 {
                     "command": "makefile.outline.setLaunchConfiguration",
-                    "when": "makefile:fullFeatureSet"
+                    "when": "makefile:localFeatureSet"
                 }
             ],
             "view/title": [
@@ -627,12 +633,12 @@
                 },
                 {
                     "command": "makefile.outline.launchDebug",
-                    "when": "view == makefile.outline",
+                    "when": "view == makefile.outline && makefile:localFeatureSet",
                     "group": "navigation@2"
                 },
                 {
                     "command": "makefile.outline.launchRun",
-                    "when": "view == makefile.outline",
+                    "when": "view == makefile.outline && makefile:localFeatureSet",
                     "group": "navigation@3"
                 }
             ],

--- a/package.json
+++ b/package.json
@@ -173,7 +173,8 @@
                 "icon": {
                     "light": "res/light/edit.svg",
                     "dark": "res/dark/edit.svg"
-                }
+                },
+                "enablement": "makefile:localFeatureSet"
             },
             {
                 "command": "makefile.outline.configure",

--- a/package.json
+++ b/package.json
@@ -141,7 +141,8 @@
                 "icon": {
                     "light": "res/light/debug.svg",
                     "dark": "res/dark/debug.svg"
-                }
+                },
+                "enablement": "makefile:localDebugFeature"
             },
             {
                 "command": "makefile.outline.launchRun",
@@ -149,7 +150,8 @@
                 "icon": {
                     "light": "res/light/run.svg",
                     "dark": "res/dark/run.svg"
-                }
+                },
+                "enablement": "makefile:localRunFeature"
             },
             {
                 "command": "makefile.outline.setBuildConfiguration",
@@ -173,8 +175,7 @@
                 "icon": {
                     "light": "res/light/edit.svg",
                     "dark": "res/dark/edit.svg"
-                },
-                "enablement": "makefile:localFeatureSet"
+                }
             },
             {
                 "command": "makefile.outline.configure",
@@ -504,11 +505,26 @@
                     "description": "%makefile-tools.configuration.makefile.compileCommandsPath.description%",
                     "scope": "resource"
                 },
-                "makefile.enableLocalDebugRun": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "%makefile-tools.configuration.makefile.enableLocalDebugRun.description%",
-                    "scope": "resource"
+                "makefile.panel.visibility": {
+                    "type": "array",
+                    "default": [],
+                    "items": 
+                    {
+                        "type": "object",
+                        "default": null,
+                        "properties": {
+                            "enableLocalDebugging": {
+                                "type": "boolean",
+                                "description": "%makefile-tools.configuration.makefile.panel.visibility.enableLocalDebugging.description%",
+                                "default": true
+                            },
+                            "enableLocalRunning": {
+                                "type": "boolean",
+                                "description": "%makefile-tools.configuration.makefile.panel.visibility.enableLocalRunning.description%",
+                                "default": true
+                            }
+                        }
+                    }
                 }
             }
         },
@@ -555,11 +571,11 @@
                 },
                 {
                     "command": "makefile.launchDebug",
-                    "when": "makefile:localFeatureSet"
+                    "when": "makefile:localDebugFeature"
                 },
                 {
                     "command": "makefile.launchRun",
-                    "when": "makefile:localFeatureSet"
+                    "when": "makefile:localRunFeature"
                 },
                 {
                     "command": "makefile.setBuildConfiguration",
@@ -571,7 +587,7 @@
                 },
                 {
                     "command": "makefile.setLaunchConfiguration",
-                    "when": "makefile:localFeatureSet"
+                    "when": "makefile:localDebugFeature"
                 },
                 {
                     "command": "makefile.outline.preConfigure",
@@ -587,11 +603,11 @@
                 },
                 {
                     "command": "makefile.outline.launchDebug",
-                    "when": "makefile:localFeatureSet"
+                    "when": "makefile:localDebugFeature"
                 },
                 {
                     "command": "makefile.outline.launchRun",
-                    "when": "makefile:localFeatureSet"
+                    "when": "makefile:localRunFeature"
                 },
                 {
                     "command": "makefile.outline.setBuildConfiguration",
@@ -603,7 +619,7 @@
                 },
                 {
                     "command": "makefile.outline.setLaunchConfiguration",
-                    "when": "makefile:localFeatureSet"
+                    "when": "makefile:localDebugFeature"
                 }
             ],
             "view/title": [
@@ -634,12 +650,12 @@
                 },
                 {
                     "command": "makefile.outline.launchDebug",
-                    "when": "view == makefile.outline && makefile:localFeatureSet",
+                    "when": "view == makefile.outline && makefile:localDebugFeature",
                     "group": "navigation@2"
                 },
                 {
                     "command": "makefile.outline.launchRun",
-                    "when": "view == makefile.outline && makefile:localFeatureSet",
+                    "when": "view == makefile.outline && makefile:localRunFeature",
                     "group": "navigation@3"
                 }
             ],

--- a/package.json
+++ b/package.json
@@ -509,14 +509,14 @@
                     "type": "object",
                     "default": null,
                     "properties": {
-                        "enableLocalDebugging": {
+                        "debug": {
                             "type": "boolean",
-                            "description": "%makefile-tools.configuration.makefile.panel.visibility.enableLocalDebugging.description%",
+                            "description": "%makefile-tools.configuration.makefile.panel.visibility.debug.description%",
                             "default": true
                         },
-                        "enableLocalRunning": {
+                        "run": {
                             "type": "boolean",
-                            "description": "%makefile-tools.configuration.makefile.panel.visibility.enableLocalRunning.description%",
+                            "description": "%makefile-tools.configuration.makefile.panel.visibility.run.description%",
                             "default": true
                         }
                     }

--- a/package.json
+++ b/package.json
@@ -505,24 +505,19 @@
                     "description": "%makefile-tools.configuration.makefile.compileCommandsPath.description%",
                     "scope": "resource"
                 },
-                "makefile.panel.visibility": {
-                    "type": "array",
-                    "default": [],
-                    "items": 
-                    {
-                        "type": "object",
-                        "default": null,
-                        "properties": {
-                            "enableLocalDebugging": {
-                                "type": "boolean",
-                                "description": "%makefile-tools.configuration.makefile.panel.visibility.enableLocalDebugging.description%",
-                                "default": true
-                            },
-                            "enableLocalRunning": {
-                                "type": "boolean",
-                                "description": "%makefile-tools.configuration.makefile.panel.visibility.enableLocalRunning.description%",
-                                "default": true
-                            }
+                "makefile.optionalFeatures": {
+                    "type": "object",
+                    "default": null,
+                    "properties": {
+                        "enableLocalDebugging": {
+                            "type": "boolean",
+                            "description": "%makefile-tools.configuration.makefile.panel.visibility.enableLocalDebugging.description%",
+                            "default": true
+                        },
+                        "enableLocalRunning": {
+                            "type": "boolean",
+                            "description": "%makefile-tools.configuration.makefile.panel.visibility.enableLocalRunning.description%",
+                            "default": true
                         }
                     }
                 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -56,6 +56,6 @@
    "makefile-tools.configuration.makefile.buildBeforeLaunch.description": "Build the current target before launch (debug/run)",
    "makefile-tools.configuration.makefile.clearOutputBeforeBuild.description": "Clear the output channel at the beginning of a build",
    "makefile-tools.configuration.makefile.compileCommandsPath.description": "The path to the compilation database file",
-   "makefile-tools.configuration.makefile.panel.visibility.enableLocalDebugging.description": "Enable debugging locally (in this host) images built by this extension",
-   "makefile-tools.configuration.makefile.panel.visibility.enableLocalRunning.description": "Enable running locally (in this host) images built by this extension"
+   "makefile-tools.configuration.makefile.panel.visibility.debug.description": "Enable debugging locally (in this host) images built by this extension",
+   "makefile-tools.configuration.makefile.panel.visibility.run.description": "Enable running locally (in this host) images built by this extension"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -55,5 +55,6 @@
    "makefile-tools.configuration.makefile.saveBeforeBuildOrConfigure.description": "Save opened files before building or configuring",
    "makefile-tools.configuration.makefile.buildBeforeLaunch.description": "Build the current target before launch (debug/run)",
    "makefile-tools.configuration.makefile.clearOutputBeforeBuild.description": "Clear the output channel at the beginning of a build",
-   "makefile-tools.configuration.makefile.compileCommandsPath.description": "The path to the compilation database file"
+   "makefile-tools.configuration.makefile.compileCommandsPath.description": "The path to the compilation database file",
+   "makefile-tools.configuration.makefile.enableLocalDebugRun.description": "Enable debugging and running local targets"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -56,5 +56,6 @@
    "makefile-tools.configuration.makefile.buildBeforeLaunch.description": "Build the current target before launch (debug/run)",
    "makefile-tools.configuration.makefile.clearOutputBeforeBuild.description": "Clear the output channel at the beginning of a build",
    "makefile-tools.configuration.makefile.compileCommandsPath.description": "The path to the compilation database file",
-   "makefile-tools.configuration.makefile.enableLocalDebugRun.description": "Enable debugging and running local targets"
+   "makefile-tools.configuration.makefile.panel.visibility.enableLocalDebugging.description": "Enable debugging locally (in this host) images built by this extension",
+   "makefile-tools.configuration.makefile.panel.visibility.enableLocalRunning.description": "Enable running locally (in this host) images built by this extension"
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -89,14 +89,14 @@ function readCurrentMakefileConfiguration(): void {
     statusBar.setConfiguration(currentMakefileConfiguration);
 }
 
-// as described in makefile.optionalFeatures
-type MakefileOptionalFeatures = {
+// as described in makefile.panel.visibility
+type MakefilePanelVisibility = {
     enableLocalDebugging: boolean,
     enableLocalRunning: boolean
 };
 
 // internal, runtime representation of an optional feature
-type MakefileOptionalFeatureDescription = {
+type MakefilePanelVisibilityDescription = {
     propertyName: string;
     default: boolean;
     value: boolean;
@@ -110,23 +110,23 @@ type MakefileOptionalFeatureDescription = {
 // * if the feature controls the UI via enablement, 
 // *    make sure enablement is handled in package.json, you are done
 // * if not, then add code to check Feature state wherever is needed.
-class MakefileOptionalFeatureDescriptions {
-    features: MakefileOptionalFeatureDescription[] = [
+class MakefilePanelVisibilityDescriptions {
+    features: MakefilePanelVisibilityDescription[] = [
         { propertyName: "enableLocalDebugging", enablement: "makefile:localDebugFeature", default: true, value: false },
         { propertyName: "enableLocalRunning", enablement: "makefile:localRunFeature", default: true, value: false }
     ];
 };
 
-let optionalFeatures = new MakefileOptionalFeatureDescriptions();
+let panelVisibility = new MakefilePanelVisibilityDescriptions();
 
 // Set all features to their defaults (enabled or disabled)
 function initOptionalFeatures() {
-    for (let feature of optionalFeatures.features) {
+    for (let feature of panelVisibility.features) {
         feature.value = feature.default;
     }
 }
 export function isOptionalFeatureEnabled(propertyName: string): boolean {
-    for (let feature of optionalFeatures.features) {
+    for (let feature of panelVisibility.features) {
         if (feature.propertyName === propertyName) {
             return feature.value;
         }
@@ -139,10 +139,10 @@ function updateOptionalFeaturesWithWorkspace() {
     let workspaceConfiguration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("makefile");
     // optionalFeatures will be set with default values.
     // override with values from the workspace
-    let features: MakefileOptionalFeatures | undefined = workspaceConfiguration.get<MakefileOptionalFeatures>("optionalFeatures") || undefined;
+    let features: MakefilePanelVisibility | undefined = workspaceConfiguration.get<MakefilePanelVisibility>("panel.visibility") || undefined;
     if (features) {
         for (let propEntry of Object.entries(features)) {
-            for (let knownFeature of optionalFeatures.features) {
+            for (let knownFeature of panelVisibility.features) {
                 if (propEntry[0] === knownFeature.propertyName) {
                     knownFeature.value = propEntry[1];
                 }
@@ -154,7 +154,7 @@ function updateOptionalFeaturesWithWorkspace() {
 }
 
 export function disableAllOptionallyVisibleCommands() {
-    for (let feature of optionalFeatures.features) {
+    for (let feature of panelVisibility.features) {
         if (feature.enablement) {
             vscode.commands.executeCommand('setContext', feature.enablement, false);
         }
@@ -163,7 +163,7 @@ export function disableAllOptionallyVisibleCommands() {
 }
 
 function enableOptionallyVisibleCommands() {
-    for (let feature of optionalFeatures.features) {
+    for (let feature of panelVisibility.features) {
         if (feature.enablement) {
             vscode.commands.executeCommand('setContext', feature.enablement, feature.value);
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -192,7 +192,7 @@ export class MakefileToolsExtension {
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
     statusBar = ui.getUI();
     await vscode.commands.executeCommand('setContext', "makefile:fullFeatureSet", false);
-    await vscode.commands.executeCommand('setContext', "makefile:localFeatureSet", false);
+    configuration.disableAllOptionallyVisibleCommands();
     extension = new MakefileToolsExtension(context);
 
     telemetry.activate();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -192,6 +192,7 @@ export class MakefileToolsExtension {
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
     statusBar = ui.getUI();
     await vscode.commands.executeCommand('setContext', "makefile:fullFeatureSet", false);
+    await vscode.commands.executeCommand('setContext', "makefile:localFeatureSet", false);
     extension = new MakefileToolsExtension(context);
 
     telemetry.activate();

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -103,6 +103,12 @@ export class LaunchTargetNode extends BaseNode {
             item.collapsibleState = vscode.TreeItemCollapsibleState.None;
             item.tooltip = localize("launch.target.currently.selected.for.debug.run.in.terminal",
                                     "The launch target currently selected for debug and run in terminal.\n{0}", this._toolTip);
+            // enablement in makefile.outline.setLaunchConfiguration is not
+            // disabling this TreeItem
+            item.command = {
+                command: "makefile.outline.setLaunchConfiguration",
+                title: "%makefile-tools.command.makefile.setLaunchConfiguration.title%"
+            }
             item.contextValue = [
                 `nodeType=launchTarget`,
             ].join(',');
@@ -170,8 +176,12 @@ export class ProjectOutlineProvider implements vscode.TreeDataProvider<BaseNode>
         if (node) {
             return node.getChildren();
         }
-
-        return [this._currentConfigurationItem, this._currentBuildTargetItem, this._currentLaunchTargetItem];
+        if (configuration.getEnableLocalDebugRun()) {
+            return [this._currentConfigurationItem, this._currentBuildTargetItem, this._currentLaunchTargetItem];
+        }
+        else {
+            return [this._currentConfigurationItem, this._currentBuildTargetItem];
+        }
     }
 
     async update(configuration: string, buildTarget: string, launchTarget: string): Promise<void> {

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -108,7 +108,7 @@ export class LaunchTargetNode extends BaseNode {
             item.command = {
                 command: "makefile.outline.setLaunchConfiguration",
                 title: "%makefile-tools.command.makefile.setLaunchConfiguration.title%"
-            }
+            };
             item.contextValue = [
                 `nodeType=launchTarget`,
             ].join(',');
@@ -176,10 +176,9 @@ export class ProjectOutlineProvider implements vscode.TreeDataProvider<BaseNode>
         if (node) {
             return node.getChildren();
         }
-        if (configuration.isOptionalFeatureEnabled("enableLocalDebugging") || configuration.isOptionalFeatureEnabled("enableLocalRunning")  ) {
+        if (configuration.isOptionalFeatureEnabled("debug") || configuration.isOptionalFeatureEnabled("run")) {
             return [this._currentConfigurationItem, this._currentBuildTargetItem, this._currentLaunchTargetItem];
-        }
-        else {
+        } else {
             return [this._currentConfigurationItem, this._currentBuildTargetItem];
         }
     }
@@ -189,25 +188,25 @@ export class ProjectOutlineProvider implements vscode.TreeDataProvider<BaseNode>
         this._currentBuildTargetItem.update(buildTarget);
         await this._currentLaunchTargetItem.update(launchTarget);
 
-        this._changeEvent.fire(null);
+        this.updateTree();
     }
 
     updateConfiguration(configuration: string): void {
         this._currentConfigurationItem.update(configuration);
-        this._changeEvent.fire(null);
+        this.updateTree();
     }
 
     updateBuildTarget(buildTarget: string): void {
         this._currentBuildTargetItem.update(buildTarget);
-        this._changeEvent.fire(null);
+        this.updateTree();
     }
 
     async updateLaunchTarget(launchTarget: string): Promise<void> {
         await this._currentLaunchTargetItem.update(launchTarget);
-        this._changeEvent.fire(null);
+        this.updateTree();
     }
 
-    async updateTree(): Promise<void> {
+    updateTree(): void {
         this._changeEvent.fire(null);
     }
 }

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -176,7 +176,7 @@ export class ProjectOutlineProvider implements vscode.TreeDataProvider<BaseNode>
         if (node) {
             return node.getChildren();
         }
-        if (configuration.getEnableLocalDebugRun()) {
+        if (configuration.isOptionalFeatureEnabled("enableLocalDebugging") || configuration.isOptionalFeatureEnabled("enableLocalRunning")  ) {
             return [this._currentConfigurationItem, this._currentBuildTargetItem, this._currentLaunchTargetItem];
         }
         else {
@@ -204,6 +204,10 @@ export class ProjectOutlineProvider implements vscode.TreeDataProvider<BaseNode>
 
     async updateLaunchTarget(launchTarget: string): Promise<void> {
         await this._currentLaunchTargetItem.update(launchTarget);
+        this._changeEvent.fire(null);
+    }
+
+    async updateTree(): Promise<void> {
         this._changeEvent.fire(null);
     }
 }


### PR DESCRIPTION
As mentioned in [issue 290](https://github.com/microsoft/vscode-makefile-tools/issues/290), we would like to propose making the local (to the host) options of debugging and running optional. This makes the vscode-makefile-tools extension friendlier to use with other extensions that allow debugging in embedded systems.
![making_local_run_debug_operations_optional](https://user-images.githubusercontent.com/100438651/157966901-4ab07f59-7215-484c-a6dc-9640f1f6e684.gif)
