### PR TITLE
Fix env sent to launch. Check CWD before launching build task.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 
 Bug fixes:
 - makePath: add "make" when only a directory path was specified. [#237](https://github.com/microsoft/vscode-makefile-tools/issues/237)
+- Keep the pre-configure environment when sending the launch target to the terminal or the debugger. [#295](https://github.com/microsoft/vscode-makefile-tools/issues/295)
 
 ## 0.3.1
 Bug fixes:

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -182,6 +182,7 @@ export class Launcher implements vscode.Disposable {
             request: 'launch',
             cwd: this.getLaunchTargetDirectory(),
             args,
+            env: util.mergeEnvironment(process.env as util.EnvironmentVariables),
             program: this.getLaunchTargetPath(),
             MIMode: miMode,
             miDebuggerPath: miDebuggerPath,
@@ -322,6 +323,7 @@ export class Launcher implements vscode.Disposable {
         }
 
         terminalOptions.cwd = this.getLaunchTargetDirectory();
+        terminalOptions.env = util.mergeEnvironment(process.env as util.EnvironmentVariables);
 
         if (!this.launchTerminal) {
             this.launchTerminal = vscode.window.createTerminal(terminalOptions);

--- a/src/make.ts
+++ b/src/make.ts
@@ -351,7 +351,7 @@ export async function doBuildTarget(progress: vscode.Progress<{}>, target: strin
 
         const result: number = await(new Promise<number>(resolve => {
             let disposable: vscode.Disposable = vscode.tasks.onDidEndTaskProcess(e => {
-                if (e. execution.task.name === makefileBuildTaskName) {
+                if (e.execution.task.name === makefileBuildTaskName) {
                     disposable.dispose();
                     resolve(e.exitCode);
                 }

--- a/src/make.ts
+++ b/src/make.ts
@@ -329,7 +329,15 @@ export async function doBuildTarget(progress: vscode.Progress<{}>, target: strin
         let myTaskArgs: vscode.ShellQuotedString[] = makeArgs.map(arg => {
             return {value: arg, quoting: quotingStlye};
         });
-        let myTaskOptions: vscode.ShellExecutionOptions = {env: util.mergeEnvironment(process.env as util.EnvironmentVariables), cwd: configuration.makeBaseDirectory()};
+
+        const cwd: string = configuration.makeBaseDirectory();
+        if (!util.checkDirectoryExistsSync(cwd)) {
+            logger.message(`Target "${target}" failed to build because CWD passed in does not exist (${cwd}).`);
+            return ConfigureBuildReturnCodeTypes.notFound;
+        }
+
+        let myTaskOptions: vscode.ShellExecutionOptions = {env: util.mergeEnvironment(process.env as util.EnvironmentVariables), cwd};
+
         let shellExec: vscode.ShellExecution = new vscode.ShellExecution(myTaskCommand, myTaskArgs, myTaskOptions);
         let myTask: vscode.Task = new vscode.Task({type: "shell", group: "build", label: makefileBuildTaskName},
         vscode.TaskScope.Workspace, makefileBuildTaskName, "makefile", shellExec);
@@ -343,7 +351,7 @@ export async function doBuildTarget(progress: vscode.Progress<{}>, target: strin
 
         const result: number = await(new Promise<number>(resolve => {
             let disposable: vscode.Disposable = vscode.tasks.onDidEndTaskProcess(e => {
-                if (e.execution.task.name === makefileBuildTaskName) {
+                if (e. execution.task.name === makefileBuildTaskName) {
                     disposable.dispose();
                     resolve(e.exitCode);
                 }

--- a/src/test/fakeSuite/Repros/test_real_make_nonWin_baseline.out
+++ b/src/test/fakeSuite/Repros/test_real_make_nonWin_baseline.out
@@ -69,12 +69,6 @@ Deduced command 'doesnt/exist/make -C {REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fake
 Make was not found on disk at the location provided via makefile.makePath or makefile.configurations[].makePath.
 Saving opened files before build.
 Building target "clean" with command: 'doesnt/exist/make clean -C {REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros/SubDir with space/'
-Executing task: "Makefile Tools Build Task" with quoting style "Strong"
- command name: doesnt/exist/make
- command args clean,-C,{REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros/SubDir with space/
-Target "clean" failed to build.
+Target "clean" failed to build because CWD passed in does not exist ({REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros/SubDir with space/).
 Building target "all" with command: 'doesnt/exist/make all -C {REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros/SubDir with space/'
-Executing task: "Makefile Tools Build Task" with quoting style "Strong"
- command name: doesnt/exist/make
- command args all,-C,{REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros/SubDir with space/
-Target "all" failed to build.
+Target "all" failed to build because CWD passed in does not exist ({REPO:VSCODE-MAKEFILE-TOOLS}/src/test/fakeSuite/Repros/SubDir with space/).

--- a/src/test/fakeSuite/Repros/test_real_make_windows_baseline.out
+++ b/src/test/fakeSuite/Repros/test_real_make_windows_baseline.out
@@ -69,12 +69,6 @@ Deduced command 'doesnt\exist\make.exe -C {REPO:VSCODE-MAKEFILE-TOOLS}\src\test\
 Make was not found on disk at the location provided via makefile.makePath or makefile.configurations[].makePath.
 Saving opened files before build.
 Building target "clean" with command: 'doesnt\exist\make.exe clean -C {REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\SubDir with space\'
-Executing task: "Makefile Tools Build Task" with quoting style "Strong"
- command name: doesnt\exist\make.exe
- command args clean,-C,{REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\SubDir with space\
-Target "clean" failed to build.
+Target "clean" failed to build because CWD passed in does not exist ({REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\SubDir with space\).
 Building target "all" with command: 'doesnt\exist\make.exe all -C {REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\SubDir with space\'
-Executing task: "Makefile Tools Build Task" with quoting style "Strong"
- command name: doesnt\exist\make.exe
- command args all,-C,{REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\SubDir with space\
-Target "all" failed to build.
+Target "all" failed to build because CWD passed in does not exist ({REPO:VSCODE-MAKEFILE-TOOLS}\src\test\fakeSuite\Repros\SubDir with space\).


### PR DESCRIPTION
This contains a fix for issue https://github.com/microsoft/vscode-makefile-tools/issues/295. Send the current process environment further to the debugger or VSCode terminal when we launch a target.

Also this fixes the CI tests. When we detect a non-existing CWD don't invoke the build task. Error and leave. Invoking a task with a non existing CWD causes a hang. It is not caught as an exception either. This was not happening before but regardless of a bug or intended change in the VSCode tasks implementation, it makes sense we validate CWD before invoking the task. This comes also with some baseline updates.