### PR TITLE
Resolve ${workspaceRoot}/${workspaceFolder} in makePath

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ The extension is going to invoke the script before every configure operation.
 ### Configuring your project
 By default, the extension will attempt to use a `make` program that resides within your $PATH to configure
 the project.  If you use a different flavor of the make tool or if it is not in your $PATH, use the
-`makefile.makePath` setting to instruct the extension where to find it.
+`makefile.makePath` setting to instruct the extension where to find it.  Provide a file/command that is in the
+system path, prefixed with `${workspaceRoot}`, or an absolute path as relative paths will not be resolved
+properly.
 
 The extension can also avoid running the `make` program when it configures your project, if you point the
 `makefile.buildLog` setting to the output of a build.

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -99,9 +99,13 @@ export function setMakePath(path: string): void { makePath = path; }
 function readMakePath(): void {
     let workspaceConfiguration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("makefile");
     makePath = workspaceConfiguration.get<string>("makePath");
-    // Don't resolve makePath to root, because make needs to be searched in the path too.
     if (!makePath) {
         logger.message("No path to the make tool is defined in the settings file.");
+    } else {
+        // Don't resolve makePath to root, because make needs to be searched in the path too.
+        // Instead, offer ability to substitute ${workspaceRoot}/${workspacePath} to the current
+        // workspace directory.
+        makePath = util.resolveSubstitutedPath(makePath);
     }
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -592,6 +592,11 @@ export function resolvePathToRoot(relPath: string): string {
     return relPath;
 }
 
+// Helper for substituting workspace paths.
+export function resolveSubstitutedPath(path: string): string {
+    return path.replace(/^\${workspace(Folder|Root)}/, getWorkspaceRoot());
+}
+
 // Schedule a task to be run at some future time. This allows other pending tasks to
 // execute ahead of the scheduled task and provides a form of async behavior for TypeScript.
 export function scheduleTask<T>(task: () => T): Promise<T> {


### PR DESCRIPTION
* Useful for providing environment wrapping scripts which bootstrap
  environment for make commands to be successful.

I created this change after spending a long time confused why this extension could not find my make wrapping script.  I needed to delegate `make` to this script so it could source a local development environment that is required to successfully build the project.

**Delegating Make Script**
```
#!/bin/bash

source .envrc &>/dev/null
make $@
```

These changes now allow for setting `makefile.makePath` to a value that is prefixed with `${workspaceFolder}`.  Confirmed via local testing that my wrapping scripts stored in `.vscode/make` now resolves properly.

I also updated the documentation to make these requirements clear because it was initially strange to me that this particular config would be treated differently than the others.