### PR TITLE
[Bug] Handle "make list" target in Makefile

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -38,7 +38,7 @@ export async function parseTargets(cancel: vscode.CancellationToken, verboseLog:
 
     // Extract the text between "# Files" and "# Finished Make data base" lines
     // There can be more than one matching section.
-    let regexpExtract: RegExp = /(# Files\n*)([\s\S]*?)(# Finished Make data base)/mg;
+    let regexpExtract: RegExp = /(# Files\n*)([\s\S]*?)(\n# Finished Make data base)/mg;
     let result: RegExpExecArray | null;
     let extractedLog: string = "";
 


### PR DESCRIPTION
* Issue: If "# Finished Make data base" in list of commands to run
  for a specific target, we would stop parsing targets after it.

* The fix is to match the target string only if it happens immediately
  after a newline, preventing it from finding a match within a target
  command.

Example: This target is in my Makefile.  All targets reported after this one are currently not parsed in `v0.4.0`.
```
.PHONY: list
list:
	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$'
```