### PR TITLE
Fix issues with compiler switch parsing and do command substitution for commands marked as safe

### DIFF
--- a/package.json
+++ b/package.json
@@ -439,6 +439,15 @@
                     },
                     "scope": "resource"
                 },
+                "makefile.safeCommands": {
+                    "type": "array",
+                    "default": [],
+                    "description": "%makefile-tools.configuration.makefile.safeCommands.description%",
+                    "items": {
+                        "type": "string"
+                    },
+                    "scope": "resource"
+                },
                 "makefile.configureOnOpen": {
                     "type": "boolean",
                     "default": true,

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -463,6 +463,15 @@ export function readExcludeCompilerNames(): void {
     logger.message(`Exclude compiler names: ${excludeCompilerNames}`);
 }
 
+let safeCommands: string[] | undefined;
+export function getSafeCommands(): string[] | undefined { return safeCommands; }
+export function setSafeCommands(compilerNames: string[]): void { safeCommands = compilerNames; }
+export function readSafeCommands(): void {
+    let workspaceConfiguration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("makefile");
+    safeCommands = workspaceConfiguration.get<string[]>("safeCommands");
+    logger.message(`Exclude compiler names: ${safeCommands}`);
+}
+
 let dryrunSwitches: string[] | undefined;
 export function getDryrunSwitches(): string[] | undefined { return dryrunSwitches; }
 export function setDryrunSwitches(switches: string[]): void { dryrunSwitches = switches; }
@@ -1020,6 +1029,7 @@ export async function initFromStateAndSettings(): Promise<void> {
     readDryrunSwitches();
     readAdditionalCompilerNames();
     readExcludeCompilerNames();
+    readSafeCommands();
     readCurrentMakefileConfiguration();
     readMakefileConfigurations();
     readCurrentTarget();
@@ -1307,6 +1317,13 @@ export async function initFromStateAndSettings(): Promise<void> {
             let updatedExcludeCompilerNames : string[] | undefined = workspaceConfiguration.get<string[]>(subKey);
             if (!util.areEqual(updatedExcludeCompilerNames, excludeCompilerNames)) {
                 readExcludeCompilerNames();
+                updatedSettingsSubkeys.push(subKey);
+            }
+
+            subKey = "safeCommands";
+            let updatedSafeCommands : string[] | undefined = workspaceConfiguration.get<string[]>(subKey);
+            if (!util.areEqual(updatedSafeCommands, safeCommands)) {
+                readSafeCommands();
                 updatedSettingsSubkeys.push(subKey);
             }
 

--- a/src/make.ts
+++ b/src/make.ts
@@ -544,7 +544,14 @@ export async function generateParseContent(progress: vscode.Progress<{}>,
         }, 5 * 1000);
 
         // The dry-run analysis should operate on english.
-        const result: util.SpawnProcessResult = await util.spawnChildProcess(configuration.getConfigurationMakeCommand(), makeArgs, util.getWorkspaceRoot(), true, true, stdout, stderr);
+        const opts: util.ProcOptions = {
+            workingDirectory: util.getWorkspaceRoot(),
+            forceEnglish: true,
+            ensureQuoted: true,
+            stdoutCallback: stdout,
+            stderrCallback: stderr
+        };
+        const result: util.SpawnProcessResult = await util.spawnChildProcess(configuration.getConfigurationMakeCommand(), makeArgs, opts);
         clearInterval(timeout);
         let elapsedTime: number = util.elapsedTimeSince(startTime);
         logger.message(`Generating dry-run elapsed time: ${elapsedTime}`);
@@ -724,7 +731,12 @@ export async function runPreConfigureScript(progress: vscode.Progress<{}>, scrip
         };
 
         // The preconfigure invocation should use the system locale.
-        const result: util.SpawnProcessResult = await util.spawnChildProcess(runCommand, scriptArgs, util.getWorkspaceRoot(), false, false, stdout, stderr);
+        const opts: util.ProcOptions = {
+            workingDirectory: util.getWorkspaceRoot(),
+            stdoutCallback: stdout,
+            stderrCallback: stderr
+        };
+        const result: util.SpawnProcessResult = await util.spawnChildProcess(runCommand, scriptArgs, opts);
         if (result.returnCode === ConfigureBuildReturnCodeTypes.success) {
             if (someErr) {
                 // Depending how the preconfigure scripts (and any inner called sub-scripts) are written,


### PR DESCRIPTION
We no longer attempt to emulate shell command parsing.  Instead we delegate that task to the shell itself.  Some interesting cases present themselves on *nix platforms where backticks are interpreted as inline commands to be run.  We can't trust all commands by default as that could be a security risk, so a new setting is also added to manage which commands are safe to run when we do the command line parsing.

My first iteration of a fix added a new parameter to `util.spawnChildProcess` which motivated me to consolidate the arguments into an object.  That change wasn't strictly necessary after a few iterations where the command execution was moved to a different part of the code.  However, I think the change adds value to the maintainability of the code, so I kept it.

Some formatting changes also happened to take place as part of this, but they are mostly whitespace related.  To simplify the review, please hide whitespace changes.

A future change may build on this and change `ToolInvocation.arguments` into an array of strings.  There are a few functions that still look through the string for specific switches using regular expressions and those regex's could potentially be removed if the arguments are already split into an array.