### PR TITLE
Preprocess multiple consecutive dashes which hang regexp engine

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -208,7 +208,18 @@ export async function preprocessDryRunOutput(cancel: vscode.CancellationToken, d
         preprocessedDryRunOutputStr = preprocessedDryRunOutputStr.replace(/;/g, "\n");
     });
 
-    // Loop through all the configure preprocess tasks, checking for cancel.
+    // Replace multiple "-" sequence because it hangs the regular expression engine.
+    // Strings with this pattern do not contain useful information to parse, they are safe to replace
+    // in our internal representation of the dryrun or build log.
+    // Replace with "- " instead of remove since this pattern does not cause hang or slow processing
+    // and so that we have a similar view of the preprocessed text.
+    preprocessTasks.push(function (): void {
+      regexp = /------/mg;
+      preprocessedDryRunOutputStr = preprocessedDryRunOutputStr.replace(regexp, "- - - - - - ");
+      regexp = /abc/mg;
+  });
+
+  // Loop through all the configure preprocess tasks, checking for cancel.
     for (const func of preprocessTasks) {
         await util.scheduleTask(func);
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -216,7 +216,6 @@ export async function preprocessDryRunOutput(cancel: vscode.CancellationToken, d
     preprocessTasks.push(function (): void {
       regexp = /------/mg;
       preprocessedDryRunOutputStr = preprocessedDryRunOutputStr.replace(regexp, "- - - - - - ");
-      regexp = /abc/mg;
   });
 
   // Loop through all the configure preprocess tasks, checking for cancel.


### PR DESCRIPTION
Fix for bug https://github.com/microsoft/vscode-makefile-tools/issues/106.
I was not able to find a way in typescript to timeout or guard the regexp run of exec API. Also I did not think it was worth to create a thread that would run regexp from terminal as a command and kill it when needed.
Instead I am removing the problematic pattern: changing "-------" into "- - - - - - ". I am not removing completely the pattern just so the intermediate preprocessed text looks somewhat similar to the original regarding these lines which usually serve as separation or layout... The "- - - " does not hang or slow down the regexp.exec api.