### PR TITLE
Remove unnecessary entrypoint not found notification, fix #394

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -782,7 +782,6 @@ export function getCommandForConfiguration(configuration: string | undefined): v
         }
 
         if (!util.checkFileExistsSync(makefileUsed)) {
-            vscode.window.showErrorMessage(localize("makefile.entry.point.not.found", "{0} entry point not found", "Makefile"));
             logger.message("The makefile entry point was not found. " +
                 "Make sure it exists at the location defined by makefile.makefilePath, makefile.configurations[].makefilePath, " +
                 "makefile.makeDirectory, makefile.configurations[].makeDirectory" +


### PR DESCRIPTION
"Makefile entry point not found" notification will appear on every VS Code launch or reload, regardless of whether the current project uses Makefile, which is annoying.

![image](https://user-images.githubusercontent.com/1430856/217384390-4f20fb7c-23fd-4f9b-b270-f64db37b3dd5.png)

If Makefile entry point does not exist, then most likely the project is not using Makefile at all. So this notification doesn't provide much value to the end user either.

This PR removes the notification.

Fix #394