### PR TITLE
Fix loc pipeline

### DIFF
--- a/jobs/loc/TranslationsImportExport.yml
+++ b/jobs/loc/TranslationsImportExport.yml
@@ -22,6 +22,11 @@ pool:
   vmImage: 'windows-latest'
 
 steps:
+- task: NodeTool@0
+  inputs:
+    versionSpec: '16.x'
+  displayName: 'Install Node.js'
+
 - task: CmdLine@2
   inputs:
     script: 'yarn install'


### PR DESCRIPTION
We have some dependencies that need updating before we can use Node 18.  Specifically, we hit the following issue:

https://github.com/mozilla/source-map/issues/432

And the work around for that issue (using an updated `source-map` module) breaks `vscode-nls-dev`: https://github.com/microsoft/vscode-nls-dev/issues/47

For now, we can revert the CI machines to using node 16.