### PR TITLE
if the make file path is a directory, search for the file

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -690,10 +690,15 @@ export function getCommandForConfiguration(configuration: string | undefined): v
     if (makefileUsed) {
         // check if the makefile path is a directory. If so, try adding `Makefile` or `makefile` 
         if (util.checkDirectoryExistsSync(makefileUsed)) {
-            makefileUsed = path.join(makefileUsed, "Makefile");
-            if (!util.checkFileExistsSync(makefileUsed)) {
-                makefileUsed = path.join(makefileUsed, "makefile");
+            let makeFileTest = path.join(makefileUsed, "Makefile");
+            if (!util.checkFileExistsSync(makeFileTest)) {
+                makeFileTest = path.join(makefileUsed, "makefile");
             }
+
+            // if we found the makefile in the directory, set the `makefileUsed` to the found file path.
+            if (util.checkFileExistsSync(makeFileTest)) {
+                makefileUsed = makeFileTest;
+            }   
         }
 
         configurationMakeArgs.push("-f");

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -688,6 +688,14 @@ export function getCommandForConfiguration(configuration: string | undefined): v
     // makefile.configurations.makefilePath overwrites makefile.makefilePath.
     let makefileUsed: string | undefined = makefileConfiguration?.makefilePath ? util.resolvePathToRoot(makefileConfiguration?.makefilePath) : makefilePath;
     if (makefileUsed) {
+        // check if the makefile path is a directory. If so, try adding `Makefile` or `makefile` 
+        if (util.checkDirectoryExistsSync(makefileUsed)) {
+            makefileUsed = path.join(makefileUsed, "Makefile");
+            if (!util.checkFileExistsSync(makefileUsed)) {
+                makefileUsed = path.join(makefileUsed, "makefile");
+            }
+        }
+
         configurationMakeArgs.push("-f");
         configurationMakeArgs.push(`${makefileUsed}`);
         // Need to rethink this (GitHub 59).


### PR DESCRIPTION
This checks if the provided makefile path from the user settings is a directory. If it's a directory, search for `Makefile` and `makefile` inside that directory. If we find the makefile, set the `makefileUsed` to that path. 

@andreeis While investigating this I wondered if we would benefit from consolidating `makefile.makefilePath` and `makefile.makeDirectory`. Maybe we could consolidate and then detect if we've gotten the directory or the file name and use that to determine whether to use `-f` of `-C`? Just thinking out loud.