### PR TITLE
Fixes for 0.7

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -36,7 +36,7 @@
             "stopOnEntry": false,
             "sourceMaps": true,
             "outFiles": [
-                "${workspaceFolder}/dist/**/*.js"
+                "${workspaceFolder}/out/**/*.js"
             ],
             "preLaunchTask": "compile",
         },

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1115,8 +1115,7 @@ export async function initFromStateAndSettings(): Promise<void> {
     // More than one setting may be updated on one settings.json save,
     // so make sure to OR the dirty state when it's calculated by a formula (not a simple TRUE value).
     vscode.workspace.onDidChangeConfiguration(async e => {
-        if (vscode.workspace.workspaceFolders &&
-            e.affectsConfiguration('makefile', vscode.workspace.workspaceFolders[0].uri)) {
+        if (vscode.workspace.workspaceFolders && e.affectsConfiguration('makefile')) {
             // We are interested in updating only some relevant properties.
             // A subset of these should also trigger an IntelliSense config provider update.
             // Avoid unnecessary updates (for example, when settings are modified via the extension quickPick).

--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -28,7 +28,10 @@ export class CppConfigurationProvider implements cpp.CustomConfigurationProvider
     private workspaceBrowseConfiguration: cpp.WorkspaceBrowseConfiguration = { browsePath: [] };
 
     private getConfiguration(uri: vscode.Uri): SourceFileConfigurationItem | undefined {
-        const norm_path: string = path.normalize(uri.fsPath);
+      let norm_path: string = path.normalize(uri.fsPath);
+      if (process.platform === "win32") {
+         norm_path = norm_path.toUpperCase();
+      }
 
         // First look in the file index computed during the last configure.
         // If nothing is found and there is a configure running right now,

--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -28,10 +28,10 @@ export class CppConfigurationProvider implements cpp.CustomConfigurationProvider
     private workspaceBrowseConfiguration: cpp.WorkspaceBrowseConfiguration = { browsePath: [] };
 
     private getConfiguration(uri: vscode.Uri): SourceFileConfigurationItem | undefined {
-      let norm_path: string = path.normalize(uri.fsPath);
-      if (process.platform === "win32") {
-         norm_path = norm_path.toUpperCase();
-      }
+        let norm_path: string = path.normalize(uri.fsPath);
+        if (process.platform === "win32") {
+           norm_path = norm_path.toUpperCase();
+        }
 
         // First look in the file index computed during the last configure.
         // If nothing is found and there is a configure running right now,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -153,7 +153,8 @@ export class MakefileToolsExtension {
 
             // These are the configurations processed during the current configure.
             // Store them in the 'delta' file index instead of the final one.
-            provider.fileIndex.set(path.normalize(uri.fsPath), sourceFileConfigurationItem);
+            provider.fileIndex.set(path.normalize((process.platform === "win32") ? uri.fsPath.toUpperCase() : uri.fsPath),
+                                                  sourceFileConfigurationItem);
             extension.getCppConfigurationProvider().logConfigurationProviderItem(sourceFileConfigurationItem);
 
             let folder: string = path.dirname(filePath);

--- a/src/util.ts
+++ b/src/util.ts
@@ -462,8 +462,8 @@ export function removeSurroundingQuotes(str: string): string {
 
 // Quote given string if it contains space and is not quoted already
 export function quoteStringIfNeeded(str: string) : string {
-   // No need to quote if there is no space present.
-   if (!str.includes(" ")) {
+   // No need to quote if there is no space or ampersand present.
+   if (!str.includes(" ") && !str.includes("&")) {
       return str;
    }
 


### PR DESCRIPTION
This PR addresses the following:
- change in the extension launch.json, debugging was broken (did not identify since when and by what but recently) because typescript sources were not found
- I found that "makefile.*" settings updates were not handled properly on edit/update for the scenario of "add folder" to workspace because the listener was also expecting only .vscode/settings.json. I believe it is correct to not assume anything about the file path of the settings because VSCode settings reader knows to read from everywhere and to apply the proper rules of defaults and overrides. No work item opened for this. Fix is in configuration.ts
- https://github.com/microsoft/vscode-makefile-tools/issues/416: for windows, when we identify a source file for which we want to save its configuration in the table, we can uppercase its path so that later, when CppTools asks about it, whatever casing it chooses, we'll find it. Fix in extension.ts and cpptools.ts
- https://github.com/microsoft/vscode-makefile-tools/issues/417: make sure paths with & are also quoted, not only the once with spaces. Fix in util.ts
