### PR TITLE
Report not found stuff in Makefile Tools UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,6 +178,14 @@
                 }
             },
             {
+               "command": "workbench.action.openWorkspaceSettings",
+               "title": "%workbench.action.openWorkspaceSettings.title%",
+               "icon": {
+                   "light": "res/light/edit.svg",
+                   "dark": "res/dark/edit.svg"
+               }
+            },
+            {
                 "command": "makefile.outline.configure",
                 "title": "%makefile-tools.command.makefile.configure.title%",
                 "icon": {
@@ -537,7 +545,6 @@
             "makefile__viewContainer": [
                 {
                     "id": "makefile.outline",
-                    "when": "makefile:fullFeatureSet",
                     "name": "%makefile-tools.configuration.views.makefile.outline.description%"
                 }
             ]
@@ -615,6 +622,10 @@
                 {
                     "command": "makefile.outline.setLaunchConfiguration",
                     "when": "makefile:localDebugFeature"
+                },
+                {
+                  "command": "workbench.action.openWorkspaceSettings",
+                  "when": "always"
                 }
             ],
             "view/title": [
@@ -635,22 +646,22 @@
                 },
                 {
                     "command": "makefile.outline.buildTarget",
-                    "when": "view == makefile.outline",
+                    "when": "makefile:fullFeatureSet && view == makefile.outline",
                     "group": "navigation@1"
                 },
                 {
                     "command": "makefile.outline.buildCleanTarget",
-                    "when": "view == makefile.outline",
+                    "when": "makefile:fullFeatureSet && view == makefile.outline",
                     "group": "1_makefileOutline@4"
                 },
                 {
                     "command": "makefile.outline.launchDebug",
-                    "when": "view == makefile.outline && makefile:localDebugFeature",
+                    "when": "makefile:fullFeatureSet && view == makefile.outline && makefile:localDebugFeature",
                     "group": "navigation@2"
                 },
                 {
                     "command": "makefile.outline.launchRun",
-                    "when": "view == makefile.outline && makefile:localRunFeature",
+                    "when": "makefile:fullFeatureSet && view == makefile.outline && makefile:localRunFeature",
                     "group": "navigation@3"
                 }
             ],
@@ -667,38 +678,53 @@
                 },
                 {
                     "command": "makefile.outline.setBuildConfiguration",
-                    "when": "view == makefile.outline && viewItem =~ /nodeType=configuration/",
+                    "when": "makefile:fullFeatureSet && view == makefile.outline && viewItem =~ /nodeType=configuration/",
                     "group": "inline@1"
                 },
                 {
                     "command": "makefile.outline.buildTarget",
-                    "when": "view == makefile.outline && viewItem =~ /nodeType=buildTarget/",
+                    "when": "makefile:fullFeatureSet && view == makefile.outline && viewItem =~ /nodeType=buildTarget/",
                     "group": "1_stateActions@1"
                 },
                 {
                     "command": "makefile.outline.buildCleanTarget",
-                    "when": "view == makefile.outline && viewItem =~ /nodeType=buildTarget/",
+                    "when": "makefile:fullFeatureSet && view == makefile.outline && viewItem =~ /nodeType=buildTarget/",
                     "group": "1_stateActions@2"
                 },
                 {
                     "command": "makefile.outline.setBuildTarget",
-                    "when": "view == makefile.outline && viewItem =~ /nodeType=buildTarget/",
+                    "when": "makefile:fullFeatureSet && view == makefile.outline && viewItem =~ /nodeType=buildTarget/",
                     "group": "inline@1"
                 },
                 {
                     "command": "makefile.outline.launchDebug",
-                    "when": "view == makefile.outline && viewItem =~ /nodeType=launchTarget/",
+                    "when": "makefile:fullFeatureSet && view == makefile.outline && viewItem =~ /nodeType=launchTarget/",
                     "group": "1_stateActions@1"
                 },
                 {
                     "command": "makefile.outline.launchRun",
-                    "when": "view == makefile.outline && viewItem =~ /nodeType=launchTarget/",
+                    "when": "makefile:fullFeatureSet && view == makefile.outline && viewItem =~ /nodeType=launchTarget/",
                     "group": "1_stateActions@2"
                 },
                 {
                     "command": "makefile.outline.setLaunchConfiguration",
-                    "when": "view == makefile.outline && viewItem =~ /nodeType=launchTarget/",
+                    "when": "makefile:fullFeatureSet && view == makefile.outline && viewItem =~ /nodeType=launchTarget/",
                     "group": "inline@1"
+                },
+                {
+                  "command": "workbench.action.openWorkspaceSettings",
+                  "when": "view == makefile.outline && viewItem =~ /nodeType=makefilePathInfo/",
+                  "group": "inline@1"
+                },
+                {
+                  "command": "workbench.action.openWorkspaceSettings",
+                  "when": "view == makefile.outline && viewItem =~ /nodeType=makePathInfo/",
+                  "group": "inline@1"
+                },
+                {
+                  "command": "workbench.action.openWorkspaceSettings",
+                  "when": "view == makefile.outline && viewItem =~ /nodeType=buildLogPathInfo/",
+                  "group": "inline@1"
                 }
             ]
         }

--- a/package.nls.json
+++ b/package.nls.json
@@ -8,6 +8,7 @@
    "makefile-tools.command.makefile.setBuildConfiguration.title": "Makefile: Set the current build configuration",
    "makefile-tools.command.makefile.setBuildTarget.title": "Makefile: Set the target to be built by make",
    "makefile-tools.command.makefile.setLaunchConfiguration.title": "Makefile: Set the make launch configuration",
+   "workbench.action.openWorkspaceSettings.title": "Preferences: Open Workspace Settings",
    "makefile-tools.command.makefile.configure.title": "Makefile: Configure",
    "makefile-tools.command.makefile.cleanConfigure.title": "Makefile: Clean Configure",
    "makefile-tools.command.makefile.preConfigure.title": "Makefile: Pre-Configure",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -785,11 +785,11 @@ export function getCommandForConfiguration(configuration: string | undefined): v
               };
               telemetry.logEvent("makeNotFound", telemetryProperties);
             }
-         } else {
+        } else {
             const makeBaseName: string = path.parse(configurationMakeCommand).base;
             const makePathInEnv: string | undefined = util.toolPathInEnv(makeBaseName);
             if (!makePathInEnv) {
-               logger.message("Make was not given any path in settings and is also not found on the environment path.");
+                logger.message("Make was not given any path in settings and is also not found on the environment path.");
 
                 // Do the users need an environment automatically set by the extension?
                 // With a kits feature or expanding on the pre-configure script.
@@ -1181,7 +1181,6 @@ export async function initFromStateAndSettings(): Promise<void> {
                 extension.getState().configureDirty = extension.getState().configureDirty ||
                                                       !currentMakefileConfiguration || !currentMakefileConfiguration.buildLog;
                 readBuildLog();
-                await extension._projectOutlineProvider.updateBuildLogPathInfo(getConfigurationBuildLog());
                 updatedSettingsSubkeys.push(subKey);
             }
 
@@ -1269,7 +1268,6 @@ export async function initFromStateAndSettings(): Promise<void> {
                 extension.getState().configureDirty = extension.getState().configureDirty ||
                                                       !buildLog || !util.checkFileExistsSync(buildLog);
                 readMakePath();
-                await extension._projectOutlineProvider.updateMakePathInfo(getConfigurationMakeCommand());
                 updatedSettingsSubkeys.push(subKey);
             }
 
@@ -1284,7 +1282,6 @@ export async function initFromStateAndSettings(): Promise<void> {
                 extension.getState().configureDirty = extension.getState().configureDirty ||
                                                       !buildLog || !util.checkFileExistsSync(buildLog);
                 readMakefilePath();
-                await extension._projectOutlineProvider.updateMakefilePathInfo(getConfigurationMakefile());
                 updatedSettingsSubkeys.push(subKey);
             }
 
@@ -1417,12 +1414,10 @@ export async function initFromStateAndSettings(): Promise<void> {
             }
 
             // Final updates in some constructs that depend on more than one of the above settings.
-            if (extension.getState().configureDirty) {
-                analyzeConfigureParams();
-                await extension._projectOutlineProvider.updateMakePathInfo(getConfigurationMakeCommand());
-                await extension._projectOutlineProvider.updateMakefilePathInfo(getConfigurationMakefile());
-                await extension._projectOutlineProvider.updateBuildLogPathInfo(getConfigurationBuildLog());
-            }
+            analyzeConfigureParams();
+            await extension._projectOutlineProvider.updateMakePathInfo(getConfigurationMakeCommand());
+            await extension._projectOutlineProvider.updateMakefilePathInfo(getConfigurationMakefile());
+            await extension._projectOutlineProvider.updateBuildLogPathInfo(getConfigurationBuildLog());
 
             // Report all the settings changes detected by now.
             // TODO: to avoid unnecessary telemetry processing, evaluate whether the changes done

--- a/src/util.ts
+++ b/src/util.ts
@@ -27,7 +27,13 @@ export type Language = "c" | "cpp" | undefined;
 
 export function checkFileExistsSync(filePath: string): boolean {
     try {
-        return fs.statSync(filePath).isFile();
+        // Often a path is added by the user to the PATH environment variable with surrounding quotes,
+        // especially on Windows where they get automatically added after TAB.
+        // These quotes become inner (not surrounding) quotes after we append various file names or do oher processing,
+        // making file sysem stats fail. Safe to remove here.
+        let filePathUnq: string = filePath;
+        filePathUnq = removeQuotes(filePathUnq);
+        return fs.statSync(filePathUnq).isFile();
     } catch (e) {
     }
     return false;
@@ -150,12 +156,7 @@ export function toolPathInEnv(name: string): string | undefined {
     // (the concept of kit for cmake extension)
 
     return envPathSplit.find(p => {
-        let fullPath: string = path.join(p, path.basename(name));
-        // Often a path is added by the user to the PATH environment variable with surrounding quotes,
-        // especially on Windows where they get automatically added after TAB.
-        // These quotes become inner (not surrounding) quotes after we append various file names or do oher processing,
-        // making file sysem stats fail. Safe to remove here.
-        fullPath = removeQuotes(fullPath);
+        const fullPath: string = path.join(p, path.basename(name));
         if (checkFileExistsSync(fullPath)) {
             return fullPath;
         }


### PR DESCRIPTION
Addressing the whole group of complaints around the popups for Make and/or Makefile missing, this PR does the following:

- removes the remaining "Make missing" popup (the Makefile missing popup was removed already with a PR from the community https://github.com/microsoft/vscode-makefile-tools/pull/415)
- keeps the logging of the missing files as it was, in the makefile tools output channel at the same time as it happened before (at load time, when reading and analyzing settings, before the configure step)
- makes the Makefile Tools UI visible also when a Makefile is missing (which before it was hidden by design), but other actions or features or UI elements remain hidden when no makefile is found (this is for the scenario of users who have code bases that contain makefiles somewhere - maybe tests or ... something else not relevant for us - but their project is not makefile based and they don't want any messages or impact from our extension being activated)
- adds 3 nodes in the UI with information about the make build tool, the root makefile that was identified and the build log (from start, we did not think of including build log in this analysis... but, when a build log is given, makefile and make are allowed to be missing so it is more clear to show info about all 3 pieces). The information given in the UI via title of tree node and tooltip is the winning rule from settings (either a default or an override...) and whether it is missing or not. The action associated with the edit pen icon is to open the settings, because there the user can define a different path for these 3: make, makefile or build log.
- I found more cases of "check if file exists" APIs failing when paths were correct and files present, because of quotes. Those quotes would exist because of "tab-tab" in windows console when adding more to the PATH variable (the OS adds those quotes when it identifies a space in the folder that's being discovered with "tab"). I would later open VSCode from that environment and our extension functions like "find in path" would split the path variable based in ";", quotes would remain and somehow the file checks would fail because of that. We found scenarios like these in the past as well but now I moved the fix in a more central place for more coverage. Fix in util.ts. No work item opened specifically for this but I'm sure it is related to some of the reports of "Makefile UI not seen" even when the makefile was present, reports that I was not able to reproduce on my end.
- 