### PR TITLE
forgot to update the version of the cpptools extension

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -109,7 +109,7 @@ export class MakefileToolsExtension {
 
     public async registerCppTools(): Promise<void> {
         if (!this.cppToolsAPI) {
-            this.cppToolsAPI = await cpp.getCppToolsApi(cpp.Version.v5);
+            this.cppToolsAPI = await cpp.getCppToolsApi(cpp.Version.v6);
         }
 
         if (this.cppToolsAPI) {


### PR DESCRIPTION
Allowing our c++23 support to be used by updating the version of the cpptools extension.