### PR TITLE
Ensure UI is able to display correct not found versus found status

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     },
     "license": "SEE LICENSE IN LICENSE.txt",
     "engines": {
-        "vscode": "^1.74.0"
+        "vscode": "^1.76.0"
     },
     "bugs": {
         "url": "https://github.com/Microsoft/vscode-makefile-tools/issues",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     },
     "license": "SEE LICENSE IN LICENSE.txt",
     "engines": {
-        "vscode": "^1.76.0"
+        "vscode": "^1.74.0"
     },
     "bugs": {
         "url": "https://github.com/Microsoft/vscode-makefile-tools/issues",
@@ -744,7 +744,7 @@
     "devDependencies": {
         "@types/mocha": "^9.0.0",
         "@types/node": "^10.17.17",
-        "@types/vscode": "^1.76.0",
+        "@types/vscode": "^1.74.0",
         "tslint": "^5.20.1",
         "tslint-microsoft-contrib": "^6.2.0",
         "tslint-no-unused-expression-chai": "^0.1.4",

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -305,12 +305,13 @@ export class ProjectOutlineProvider implements vscode.TreeDataProvider<BaseNode>
        if (!pathInSettings) {
          return `${kind}: [Unset]`;
        }
-
-       const pathBase: string | undefined = (searchInPath && path.parse(pathInSettings).dir === "") ? path.parse(pathInSettings).base : undefined;
+       
+       const pathInSettingsToTest = !pathInSettings.endsWith(".exe") && kind === "Make" && process.platform === "win32" ? pathInSettings.concat(".exe") : pathInSettings;
+       const pathBase: string | undefined = (searchInPath && path.parse(pathInSettingsToTest).dir === "") ? path.parse(pathInSettingsToTest).base : undefined;
        const pathInEnv: string | undefined = pathBase ? (path.join(util.toolPathInEnv(pathBase) || "", pathBase)) : undefined;
-       const finalPath: string = pathInEnv || pathInSettings;
+       const finalPath: string = pathInEnv || pathInSettingsToTest;
        return (!util.checkFileExistsSync(finalPath) ? `${kind} (not found)` : `${kind}`) + `: [${makeRelative ? util.makeRelPath(finalPath, util.getWorkspaceRoot()) : finalPath}]`;
-    }   
+    }
 
     async update(configuration: string | undefined,
                  buildTarget: string | undefined,

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -306,7 +306,7 @@ export class ProjectOutlineProvider implements vscode.TreeDataProvider<BaseNode>
          return `${kind}: [Unset]`;
        }
        
-       const pathInSettingsToTest = !pathInSettings.endsWith(".exe") && kind === "Make" && process.platform === "win32" ? pathInSettings.concat(".exe") : pathInSettings;
+       const pathInSettingsToTest = process.platform === "win32" && !pathInSettings.endsWith(".exe") && kind === "Make" ? pathInSettings.concat(".exe") : pathInSettings;
        const pathBase: string | undefined = (searchInPath && path.parse(pathInSettingsToTest).dir === "") ? path.parse(pathInSettingsToTest).base : undefined;
        const pathInEnv: string | undefined = pathBase ? (path.join(util.toolPathInEnv(pathBase) || "", pathBase)) : undefined;
        const finalPath: string = pathInEnv || pathInSettingsToTest;

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -306,7 +306,7 @@ export class ProjectOutlineProvider implements vscode.TreeDataProvider<BaseNode>
          return `${kind}: [Unset]`;
        }
        
-       const pathInSettingsToTest = process.platform === "win32" && !pathInSettings.endsWith(".exe") && kind === "Make" ? pathInSettings.concat(".exe") : pathInSettings;
+       const pathInSettingsToTest: string | undefined = process.platform === "win32" && !pathInSettings?.endsWith(".exe") && kind === "Make" ? pathInSettings?.concat(".exe") : pathInSettings;
        const pathBase: string | undefined = (searchInPath && path.parse(pathInSettingsToTest).dir === "") ? path.parse(pathInSettingsToTest).base : undefined;
        const pathInEnv: string | undefined = pathBase ? (path.join(util.toolPathInEnv(pathBase) || "", pathBase)) : undefined;
        const finalPath: string = pathInEnv || pathInSettingsToTest;

--- a/yarn.lock
+++ b/yarn.lock
@@ -231,7 +231,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
   integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
 
-"@types/vscode@^1.76.0":
+"@types/vscode@^1.74.0":
   version "1.76.0"
   resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.76.0.tgz#967c0fbe09921818bbf201f1cbcb81b981c6249c"
   integrity sha512-CQcY3+Fe5hNewHnOEAVYj4dd1do/QHliXaknAEYSXx2KEHUzFibDZSKptCon+HPgK55xx20pR+PBJjf0MomnBA==


### PR DESCRIPTION
During testing, I found a bug where in Windows, if the user had `make` on path, it wasn't finding it and it was displaying `(not found)` in the UI, this fixes it. 