### PR TITLE
check if our configuration is empty to determine if we can provide

### DIFF
--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -102,7 +102,7 @@ export class CppConfigurationProvider implements cpp.CustomConfigurationProvider
     }
 
     public async canProvideBrowseConfiguration(): Promise<boolean> {
-        return true;
+        return this.workspaceBrowseConfiguration.browsePath.length > 0;
     }
 
     public async canProvideBrowseConfigurationsPerFolder(): Promise<boolean> {


### PR DESCRIPTION
I did check that this still provides information in normal scenarios, so based on a very simple test, this doesn't break. 