### PR TITLE
don't cache when empty, don't configure when fullFeatureSet is false

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,6 +55,13 @@ export class MakefileToolsExtension {
         }
     }
 
+    private fullFeatureSet: boolean = false;
+    public getFullFeatureSet(): boolean { return this.fullFeatureSet; }
+    public async setFullFeatureSet(newValue: boolean): Promise<void> {
+        await vscode.commands.executeCommand('setContext', "makefile:fullFeatureSet", newValue);
+        this.fullFeatureSet = newValue;
+    }
+
     // Used for calling cppToolsAPI.notifyReady only once in a VSCode session.
     private ranNotifyReadyInSession: boolean = false;
     public getRanNotifyReadyInSession() : boolean { return this.ranNotifyReadyInSession; }
@@ -192,9 +199,9 @@ export class MakefileToolsExtension {
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
     statusBar = ui.getUI();
-    await vscode.commands.executeCommand('setContext', "makefile:fullFeatureSet", false);
-    configuration.disableAllOptionallyVisibleCommands();
     extension = new MakefileToolsExtension(context);
+    configuration.disableAllOptionallyVisibleCommands();
+    await extension.setFullFeatureSet(false);
 
     telemetry.activate();
 
@@ -360,7 +367,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     // Read configuration info from settings
     await configuration.initFromStateAndSettings();
 
-    if (configuration.getConfigureOnOpen()) {
+    if (configuration.getConfigureOnOpen() && extension.getFullFeatureSet()) {
         // Always clean configure on open
         await make.cleanConfigure(make.TriggeredBy.cleanConfigureOnOpen);
     }


### PR DESCRIPTION
We realized that on startup, even when we didn't find makefiles, or didn't find things that set `fullFeatureSet` to true, we still were registering with cpptools and calling `notifyReady`. This caused us to take over control of intellisense with cpptools which caused a broken experience. I believe this fixes this because it first checks that fullFeatureSet is true. Additionally, it still lets manual configures to happen (from the command pallette). 

Additionally, we check for an empty configuration before we cache. If it's empty, we don't cache.