### PR TITLE
add workflow on releases that closes fixed-pending-release issues

### DIFF
--- a/.github/workflows/close-fixed-pending-release.yml
+++ b/.github/workflows/close-fixed-pending-release.yml
@@ -8,7 +8,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Close issues marked 'fixed-pending-release'
-              uses: gcampbell-msft/fixed-pending-release@0.0.11
+              uses: gcampbell-msft/fixed-pending-release@0.0.12
               with:
                 token: ${{ secrets.GITHUB_TOKEN }}
                 label: fixed-pending-release

--- a/.github/workflows/close-fixed-pending-release.yml
+++ b/.github/workflows/close-fixed-pending-release.yml
@@ -1,0 +1,14 @@
+name: Closed fixed-pending-release issues
+on:
+    release:
+        types: [published]
+
+jobs:
+    close_fixed_pending_release:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Close issues marked 'fixed-pending-release'
+              uses: gcampbell-msft/fixed-pending-release@0.0.11
+              with:
+                token: ${{ secrets.GITHUB_TOKEN }}
+                label: fixed-pending-release


### PR DESCRIPTION
This PR adds a workflow that runs when a new release is published and it goes through and closes issues that are labeled as `fixed-pending-release`.