### PR TITLE
Honor workspace trust in VSCode. Also warn about possible code being executed under --dry-run first time it is invoked.

### DIFF
--- a/package.json
+++ b/package.json
@@ -568,12 +568,41 @@
             "makefile__viewContainer": [
                 {
                     "id": "makefile.outline",
+                    "when": "isWorkspaceTrusted",
                     "name": "%makefile-tools.configuration.views.makefile.outline.description%"
                 }
             ]
         },
         "menus": {
             "commandPalette": [
+                {
+                    "command": "makefile.configure",
+                    "when": "isWorkspaceTrusted"
+                },
+                {
+                    "command": "makefile.cleanConfigure",
+                    "when": "isWorkspaceTrusted"
+                },
+                {
+                  "command": "makefile.outline.openMakefilePathSetting",
+                  "when": "isWorkspaceTrusted"
+                },
+                {
+                   "command": "makefile.outline.openMakefileFile",
+                   "when": "isWorkspaceTrusted"
+                },
+                {
+                   "command": "makefile.outline.openMakePathSetting",
+                   "when": "isWorkspaceTrusted"
+                },
+                {
+                   "command": "makefile.outline.openBuildLogSetting",
+                   "when": "isWorkspaceTrusted"
+                },
+                {
+                   "command": "makefile.outline.openBuildLogFile",
+                   "when": "isWorkspaceTrusted"
+                },
                 {
                     "command": "makefile.preConfigure",
                     "when": "makefile:fullFeatureSet"
@@ -661,6 +690,10 @@
                 {
                     "command": "makefile.outline.setLaunchConfiguration",
                     "when": "never"
+                },
+                {
+                    "command": "makefile.resetState",
+                    "when": "isWorkspaceTrusted"
                 }
             ],
             "view/title": [
@@ -837,6 +870,12 @@
         "nanoid": "^3.1.20",
         "minimatch": "^3.0.5",
         "xml2js": "^0.5.0"
+    },
+    "capabilities": {
+      "untrustedWorkspaces": {
+         "supported": false,
+         "description": ""
+      }
     }
 
 }

--- a/package.json
+++ b/package.json
@@ -584,24 +584,24 @@
                     "when": "isWorkspaceTrusted"
                 },
                 {
-                  "command": "makefile.outline.openMakefilePathSetting",
-                  "when": "isWorkspaceTrusted"
+                    "command": "makefile.outline.openMakefilePathSetting",
+                    "when": "isWorkspaceTrusted"
                 },
                 {
-                   "command": "makefile.outline.openMakefileFile",
-                   "when": "isWorkspaceTrusted"
+                    "command": "makefile.outline.openMakefileFile",
+                    "when": "isWorkspaceTrusted"
                 },
                 {
-                   "command": "makefile.outline.openMakePathSetting",
-                   "when": "isWorkspaceTrusted"
+                    "command": "makefile.outline.openMakePathSetting",
+                    "when": "isWorkspaceTrusted"
                 },
                 {
-                   "command": "makefile.outline.openBuildLogSetting",
-                   "when": "isWorkspaceTrusted"
+                    "command": "makefile.outline.openBuildLogSetting",
+                    "when": "isWorkspaceTrusted"
                 },
                 {
-                   "command": "makefile.outline.openBuildLogFile",
-                   "when": "isWorkspaceTrusted"
+                    "command": "makefile.outline.openBuildLogFile",
+                    "when": "isWorkspaceTrusted"
                 },
                 {
                     "command": "makefile.preConfigure",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -825,13 +825,18 @@ export async function getCommandForConfiguration(configuration: string | undefin
             await extension.setFullFeatureSet(false);
             disableAllOptionallyVisibleCommands();
         } else {
+            if (vscode.workspace.isTrusted) { // full feature set ON only for trusted workspaces
+                await extension.setFullFeatureSet(true);
+                enableOptionallyVisibleCommands();
+            }
+        }
+    } else {
+        // If we have a build log, then we want Makefile Tools to be fully active and the UI visible,
+        // unless the workspace is untrusted.
+        if (vscode.workspace.isTrusted) {
             await extension.setFullFeatureSet(true);
             enableOptionallyVisibleCommands();
         }
-    } else {
-        // If we have a build log, then we want Makefile Tools to be fully active and the UI visible.
-        await extension.setFullFeatureSet(true);
-        enableOptionallyVisibleCommands();
     }
 }
 
@@ -1095,6 +1100,11 @@ export async function initFromSettings(activation: boolean = false): Promise<voi
                                              getConfigurationMakefile(),
                                              getConfigurationMakeCommand(),
                                              getConfigurationBuildLog());
+
+    // Listen to the workspace trust change event
+    vscode.workspace.onDidGrantWorkspaceTrust(async e => {
+        await getCommandForConfiguration(currentMakefileConfiguration); // this refreshes fullFeatureSet and enables visible features
+    });
 
     // Verify the dirty state of the IntelliSense config provider and update accordingly.
     // The makefile.configureOnEdit setting can be set to false when this behavior is inconvenient.
@@ -1438,7 +1448,9 @@ export async function initFromSettings(activation: boolean = false): Promise<voi
             let wasLocalDebugEnabled: boolean = isOptionalFeatureEnabled("debug");
             let wasLocalRunningEnabled: boolean   = isOptionalFeatureEnabled("run");
             await readFeaturesVisibility();
-            enableOptionallyVisibleCommands();
+            if (vscode.workspace.isTrusted) {
+                enableOptionallyVisibleCommands();
+            }
             let isLocalDebugEnabled: boolean = isOptionalFeatureEnabled("debug");
             let isLocalRunningEnabled: boolean   = isOptionalFeatureEnabled("run");
             if ((wasLocalDebugEnabled !== isLocalDebugEnabled) || (wasLocalRunningEnabled !== isLocalRunningEnabled)) {

--- a/src/make.ts
+++ b/src/make.ts
@@ -995,7 +995,8 @@ export async function configure(triggeredBy: TriggeredBy, updateTargets: boolean
     logger.showOutputChannel();
     let yesButton: string = localize("yes.dont.show.again", "Yes (don't show again)");
     let noButton: string = localize("no", "No");
-    const chosen: vscode.MessageItem | undefined = await vscode.window.showErrorMessage<vscode.MessageItem>("Configuring project. Code can still execute in --dry-run mode. Do you want to continue?",
+    const chosen: vscode.MessageItem | undefined = await vscode.window.showErrorMessage<vscode.MessageItem>(localize("code.can.execute.dryrun.mode.continue",
+                                                                                       "Configuring project. Code can still execute in --dry-run mode. Do you want to continue?"),
     {
       title: yesButton,
       isCloseAffordance: false,

--- a/src/make.ts
+++ b/src/make.ts
@@ -56,6 +56,7 @@ export enum ConfigureBuildReturnCodeTypes {
     other = -5,
     saveFailed = -6,
     fullFeatureFalse = -7,
+    untrusted = -8,
 }
 
 export enum Operations {
@@ -605,6 +606,14 @@ export async function generateParseContent(progress: vscode.Progress<{}>,
 }
 
 export async function prePostConfigureHelper(titles: {configuringScript: string, cancelling: string}, configureScriptMethod: (progress: vscode.Progress<{}>) => Promise<number>, setConfigureScriptState: (value: boolean) => void, logConfigureScriptTelemetry: (elapsedTime: number, exitCode: number) => void): Promise<number> {
+    // No pre/post configure execution in untrusted workspaces.
+    // The check is needed also here in addition to disabling all UI and actions because,
+    // depending on settings, this can run automatically at project load.
+    if (!vscode.workspace.isTrusted) {
+        logger.message("No script can run in an untrusted workspace.");
+        return ConfigureBuildReturnCodeTypes.untrusted;
+    }
+
     // check for being blocked by operations.
     if (blockedByOp(Operations.preConfigure)) {
         return ConfigureBuildReturnCodeTypes.blocked;
@@ -969,10 +978,46 @@ function getRelevantConfigStats(stats: any): ConfigureSubphaseStatusItem[] {
 // (thus disappearing from the log with commands) will still have IntelliSense loaded
 // until the next clean configure.
 export async function configure(triggeredBy: TriggeredBy, updateTargets: boolean = true): Promise<number> {
-  // Mark that this workspace had at least one attempt at configuring, before any chance of early return,
-  // to accurately identify whether this project configured successfully out of the box or not.
-  let ranConfigureInCodebaseLifetime: boolean =
-    extension.getState().ranConfigureInCodebaseLifetime;
+  // Before running the --dry-run type of configure for the first time, even in a trusted workspace,
+  // notify the user that it is possible some code to be executed even under "--dry-run" mode.
+  // Note that this is a state variable and can be reseted via the command resetState, causing the popup to show again
+  // even if a successfull --dry-run configure has been run in the past.
+  let ranDryRunInCodebaseLifetime: boolean = extension.getState().ranDryRunInCodebaseLifetime;
+  if (!ranDryRunInCodebaseLifetime && !configuration.getBuildLog()) {
+    // The window popup message should be concise but more logging can be useful in the output channel.
+    logger.message("The Makefile Tools extension process of configuring your project is about to run 'make --dry-run' in order to parse the output for useful information. " +
+                   "This is needed to calculate accurate IntelliSense and targets information. " +
+                   "Although in general 'make --dry-run' only lists (without executing) the operations 'make' would do in the current context, " +
+                   "it is still possible some code to be executed, like $(shell) syntax in the makefile or recursive invocations of the $(MAKE) variable.");
+    logger.message("If you don't feel comfortable allowing this configure process and 'make --dry-run' to be invoked by the extension, " +
+                   "you can chose a recent full, clean, verbose and up-to-date build log as an alternative, via the setting 'makefile.buildLog'. ");
+    // Also, show the output channel for that message to be visible.
+    logger.showOutputChannel();
+    let yesButton: string = localize("yes.dont.show.again", "Yes (don't show again)");
+    let noButton: string = localize("no", "No");
+    const chosen: vscode.MessageItem | undefined = await vscode.window.showErrorMessage<vscode.MessageItem>("Configuring project. Code can still execute in --dry-run mode. Do you want to continue?",
+    {
+      title: yesButton,
+      isCloseAffordance: false,
+    },
+    {
+      title: noButton,
+      isCloseAffordance: true
+    });
+
+    // The 'code possibly executed under --dry-run' warning makes sense only for the configure operation.
+    // This is when the user may not expect this to happen. Does not apply for a build or debug/launch and even for pre/post configure which,
+    // if set by the user, they represent intentional commands.
+    if (chosen === undefined || chosen.title === noButton) {
+      return ConfigureBuildReturnCodeTypes.untrusted;
+    }
+
+    extension.getState().ranDryRunInCodebaseLifetime = true;
+  }
+
+  // Mark that this workspace had at least one attempt at configuring (of any kind: --dry-run or buildLog), before any chance of early return,
+  // to accurately identify in telemetry whether this project configured successfully out of the box or not.
+  let ranConfigureInCodebaseLifetime: boolean = extension.getState().ranConfigureInCodebaseLifetime;
   extension.getState().ranConfigureInCodebaseLifetime = true;
 
   // If `fullFeatureSet` is false and it wasn't a manual command invocation, return and `other` return value.
@@ -989,6 +1034,14 @@ export async function configure(triggeredBy: TriggeredBy, updateTargets: boolean
 
   if (!saveAll()) {
     return ConfigureBuildReturnCodeTypes.saveFailed;
+  }
+
+  // No configure execution in untrusted workspaces.
+  // The check is needed also here in addition to disabling all UI and actions because,
+  // depending on settings, this can run automatically at project load.
+  if (!vscode.workspace.isTrusted) {
+    logger.message("Cannot configure a project in an untrusted workspace.");
+    return ConfigureBuildReturnCodeTypes.untrusted;
   }
 
   // Same start time for configure and an eventual pre-configure.

--- a/src/state.ts
+++ b/src/state.ts
@@ -53,6 +53,18 @@ export class StateManager {
     this._update('ranConfigureInCodebaseLifetime', v);
   }
 
+  // Whether this project had any --dry-run specific configure attempt before
+  // (it didn't have to succeed or even complete).
+  // This is used in order to notify the user via a Yes(don't show again)/No popup
+  // that some makefile code could still execute even in --dry-run mode.
+  // Once the user decides 'Yes(don't show again)' the popup is not shown.
+  get ranDryRunInCodebaseLifetime(): boolean {
+    return this._get<boolean>('ranDryRunInCodebaseLifetime') || false;
+  }
+  set ranDryRunInCodebaseLifetime(v: boolean) {
+    this._update('ranDryRunInCodebaseLifetime', v);
+  }
+
   // If the project needs a clean configure as a result
   // of an operation that alters the configure state
   // (makefile configuration change, build target change,
@@ -75,6 +87,7 @@ export class StateManager {
     this.buildTarget = undefined;
     this.launchConfiguration = undefined;
     this.ranConfigureInCodebaseLifetime = false;
+    this.ranDryRunInCodebaseLifetime = false;
     this.configureDirty = false;
 
     if (reloadWindow) {


### PR DESCRIPTION
Honor workspace trust in VSCode.
Also warn about possible code being executed under --dry-run first time it is invoked.
Fix for https://github.com/microsoft/vscode-makefile-tools/issues/506. 