### PR TITLE
Avoid relativizing paths in the project outline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Improvements:
 - Add support for post-configure and pre-configure script arguments, both globally and per configuration. [#151](https://github.com/microsoft/vscode-makefile-tools/issues/151)
 - Honor workspace trust in VS Code and warn about code being run during dry-run. [#514](https://github.com/microsoft/vscode-makefile-tools/pull/514)
 - Ship the parseCompilerArgs script with the extension to avoid race conditions. [#516](https://github.com/microsoft/vscode-makefile-tools/issues/516), [#475](https://github.com/microsoft/vscode-makefile-tools/issues/475)
+- Avoid relativizing paths in the project outline. [#519](https://github.com/microsoft/vscode-makefile-tools/pull/519) [@drok sponsored by @Mergesium](https://github.com/drok)
 
 ## 0.7.0
 Improvements:

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -336,9 +336,9 @@ export class ProjectOutlineProvider implements vscode.TreeDataProvider<BaseNode>
         this._currentConfigurationItem.update(configuration || this._unsetString);
         this._currentBuildTargetItem.update(buildTarget || this._unsetString);
         await this._currentLaunchTargetItem.update(launchTarget || this._unsetString);
-        this._currentMakefilePathInfoItem.update(makefilePathInfo || this._unsetString, this.pathDisplayed(makefilePathInfo, "Makefile", false, true));
+        this._currentMakefilePathInfoItem.update(makefilePathInfo || this._unsetString, this.pathDisplayed(makefilePathInfo, "Makefile", false, false));
         this._currentMakePathInfoItem.update(makePathInfo || this._unsetString, this.pathDisplayed(makePathInfo, "Make", true, false));
-        this._currentBuildLogPathInfoItem.update(buildLogInfo || this._unsetString, this.pathDisplayed(buildLogInfo, "Build Log", false, true));
+        this._currentBuildLogPathInfoItem.update(buildLogInfo || this._unsetString, this.pathDisplayed(buildLogInfo, "Build Log", false, false));
 
         this.updateTree();
     }


### PR DESCRIPTION
In the project outline view, paths for the Makefile and build log were automatically made relative. If the setting was an absolute path, the result would be ugly:

For a makeDirectory setting '/tmp/amhello-debug', the outline would print

Makefile: [../../../tmp/amhello-debug/Makefile]

This was not only unsightly, but also wrong. See
https://unix.stackexchange.com/questions/13858/do-the-parent-directorys-permissions-matter-when-accessing-a-subdirectory

In short, if one of the parent directories (..) would be inaccessible, the ../../../tmp/amhello-debug path is wrong because it's inaccessible, even though /tmp/amhello-debug is accessible.