### PR TITLE
Fix arguments for preconfigure and postconfigure for linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.8
 Bug Fixes:
 - Fix a bug where the first argument for pre/post-configure args didn't have the proper spacing in front of it [PR #530](https://github.com/microsoft/vscode-makefile-tools/pull/530)
+- Fix a bug where we weren't handling pre/post-configure args for the non-windows scenarios. [#531](https://github.com/microsoft/vscode-makefile-tools/issues/531)
 
 Improvements:
 - Add support for a post configure script. [#391](https://github.com/microsoft/vscode-makefile-tools/issues/391)

--- a/src/make.ts
+++ b/src/make.ts
@@ -773,7 +773,7 @@ export async function runPrePostConfigureScript(progress: vscode.Progress<{}>, s
         wrapScriptContent += `set > "${wrapScriptOutFile}"`;
         wrapScriptFile += ".bat";
     } else {
-        wrapScriptContent = `source '${scriptFile}'\n`;
+        wrapScriptContent = `source '${scriptFile}' ${scriptArgs.length > 0 ? scriptArgs.join(" ").toString() : ""}\n`;
         wrapScriptContent += `printenv > '${wrapScriptOutFile}'`;
         wrapScriptFile += ".sh";
     }


### PR DESCRIPTION
We previously weren't handling the arguments in the linux scenario, this fixes this.

Thanks to @156898293 for helping me test and confirm that this fixes the issue.