### PR TITLE
add telemetry event for dryRunWarning popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Bug Fixes:
 
 - Fix an issue with XDG_RUNTIME_DIR where we tried to reference the directory, but it didn't exist. [#553](https://github.com/microsoft/vscode-makefile-tools/pull/555)
 
+Improvements:
+
+- Add telemetry about how many users are hitting the dry-run warning and how many users are stopping the dry-run process due to it. [#565](https://github.com/microsoft/vscode-makefile-tools/pull/565)
+
 ## 0.8
 Bug Fixes:
 - Fix a bug where the first argument for pre/post-configure args didn't have the proper spacing in front of it [PR #530](https://github.com/microsoft/vscode-makefile-tools/pull/530)

--- a/src/make.ts
+++ b/src/make.ts
@@ -1020,8 +1020,8 @@ export async function configure(triggeredBy: TriggeredBy, updateTargets: boolean
     // This is when the user may not expect this to happen. Does not apply for a build or debug/launch and even for pre/post configure which,
     // if set by the user, they represent intentional commands.
 
-    // If the user answered yes, to continue with the --dry-run (configure) `dryRunApproved` will be true.
-    // If the user decided not to continue with the --dry-run (configure), it will be false.
+    // If the user answered yes to continue with the --dry-run (configure), `dryRunApproved` will be true.
+    // If the user decided not to continue with the --dry-run (configure), `dryRunApproved` will be false.
     const telemetryProperties: telemetry.Properties = {
       dryRunApproved: chosen?.title === yesButton ? "true" : "false",
       triggeredBy: triggeredBy,

--- a/src/make.ts
+++ b/src/make.ts
@@ -1019,6 +1019,15 @@ export async function configure(triggeredBy: TriggeredBy, updateTargets: boolean
     // The 'code possibly executed under --dry-run' warning makes sense only for the configure operation.
     // This is when the user may not expect this to happen. Does not apply for a build or debug/launch and even for pre/post configure which,
     // if set by the user, they represent intentional commands.
+
+    // If the user answered yes, to continue with the --dry-run (configure) `dryRunApproved` will be true.
+    // If the user decided not to continue with the --dry-run (configure), it will be false.
+    const telemetryProperties: telemetry.Properties = {
+      dryRunApproved: chosen?.title === yesButton ? "true" : "false",
+      triggeredBy: triggeredBy,
+    };
+    telemetry.logEvent("dryRunWarning", telemetryProperties);
+
     if (chosen === undefined || chosen.title === noButton) {
       return ConfigureBuildReturnCodeTypes.untrusted;
     }


### PR DESCRIPTION
Add telemetry for the dry run warning popup and how many users are stopping the dry-run (configure) process due to it. 