### PR TITLE
Remove dry-run popup, replace with configureOnOpen questions

### DIFF
--- a/package.json
+++ b/package.json
@@ -479,7 +479,7 @@
         },
         "makefile.configureOnOpen": {
           "type": "boolean",
-          "default": true,
+          "default": null,
           "description": "%makefile-tools.configuration.makefile.configureOnOpen.description%",
           "scope": "resource"
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -751,7 +751,7 @@ export async function activate(
       const chosen = await vscode.window.showInformationMessage<Choice1>(
         localize(
           "extension.configureOnOpen",
-          "Would you like to configure with the Makefile Tools extension?"
+          "Would you like to configure this workspace with the Makefile Tools extension?"
         ),
         {},
         { title: localize("yes", "Yes"), doConfigure: true },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,6 @@ import * as configuration from "./configuration";
 import * as cpptools from "./cpptools";
 import * as launch from "./launch";
 import { promises as fs } from "fs";
-import * as logger from "./logger";
 import * as make from "./make";
 import * as parser from "./parser";
 import * as path from "path";
@@ -20,7 +19,7 @@ import * as vscode from "vscode";
 import * as cpp from "vscode-cpptools";
 
 import * as nls from "vscode-nls";
-import { readBuildLog } from "./configuration";
+import { TelemetryEventProperties } from "@vscode/extension-telemetry";
 nls.config({
   messageFormat: nls.MessageFormat.bundle,
   bundleFormat: nls.BundleFormat.standalone,
@@ -761,6 +760,7 @@ export async function activate(
       if (!chosen) {
         // User cancelled, they don't want to configure.
         shouldConfigure = false;
+        telemetry.logConfigureOnOpenTelemetry(false);
       } else {
         // ask them if they always want to configure on open.
         // TODO: More work to do here to have the right flow.
@@ -784,7 +784,7 @@ export async function activate(
             ];
         interface Choice2 {
           title: string;
-          persistMode: "user" | "workspace";
+          persistMode: telemetry.ConfigureOnOpenScope;
         }
 
         vscode.window
@@ -797,6 +797,7 @@ export async function activate(
           .then(async (choice) => {
             if (!choice) {
               // User cancelled. Do nothing.
+              telemetry.logConfigureOnOpenTelemetry(chosen.doConfigure);
               return;
             }
 
@@ -814,6 +815,11 @@ export async function activate(
                   configTarget
                 );
             }
+
+            telemetry.logConfigureOnOpenTelemetry(
+              chosen.doConfigure,
+              choice.persistMode
+            );
           });
 
         shouldConfigure = chosen.doConfigure;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -739,7 +739,6 @@ export async function activate(
   // 0x755 means rwxr-xr-x (read and execute for everyone, write for owner).
   await fs.chmod(parseCompilerArgsScript, 0o755);
 
-  // TODO: Need to add logging and/or telemetry.
   if (extension.getFullFeatureSet()) {
     let shouldConfigure = configuration.getConfigureOnOpen();
     if (shouldConfigure === null) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -767,11 +767,11 @@ export async function activate(
         const persistMessage = chosen.doConfigure
           ? localize(
               "always.configure.on.open",
-              "Always configure projects upon opening?"
+              "Always configure C++ IntelliSense using information from your Makefiles upon opening?"
             )
           : localize(
               "never.configure.on.open",
-              "Configure projects upon opening?"
+              "Configure C++ IntelliSense using information from your Makefiles upon opening?"
             );
         const buttonMessages = chosen.doConfigure
           ? [localize("yes.button", "Yes"), localize("no.button", "No")]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -751,7 +751,7 @@ export async function activate(
       const chosen = await vscode.window.showInformationMessage<Choice1>(
         localize(
           "extension.configureOnOpen",
-          "Would you like to configure this workspace with the Makefile Tools extension?"
+          "Would you like to configure C++ IntelliSense for this workspace using information from your Makefiles?"
         ),
         {},
         { title: localize("yes", "Yes"), doConfigure: true },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -740,6 +740,7 @@ export async function activate(
   // 0x755 means rwxr-xr-x (read and execute for everyone, write for owner).
   await fs.chmod(parseCompilerArgsScript, 0o755);
 
+  // TODO: Need to add logging and/or telemetry.
   if (extension.getFullFeatureSet()) {
     let shouldConfigure = configuration.getConfigureOnOpen();
     if (shouldConfigure === null) {
@@ -786,7 +787,7 @@ export async function activate(
           persistMode: "user" | "workspace";
         }
 
-        const prompt = vscode.window
+        vscode.window
           .showInformationMessage<Choice2>(
             persistMessage,
             {},
@@ -814,13 +815,15 @@ export async function activate(
                 );
             }
           });
+
+        shouldConfigure = chosen.doConfigure;
+
+        if (shouldConfigure === true) {
+          // We've opened a new workspace folder, and the user wants us to configure it now.
+          await make.cleanConfigure(make.TriggeredBy.cleanConfigureOnOpen);
+        }
       }
     }
-  }
-
-  if (configuration.getConfigureOnOpen() && extension.getFullFeatureSet()) {
-    // Always clean configure on open
-    await make.cleanConfigure(make.TriggeredBy.cleanConfigureOnOpen);
   }
 
   // Analyze settings for type validation and telemetry

--- a/src/state.ts
+++ b/src/state.ts
@@ -53,18 +53,6 @@ export class StateManager {
     this._update("ranConfigureInCodebaseLifetime", v);
   }
 
-  // Whether this project had any --dry-run specific configure attempt before
-  // (it didn't have to succeed or even complete).
-  // This is used in order to notify the user via a Yes(don't show again)/No popup
-  // that some makefile code could still execute even in --dry-run mode.
-  // Once the user decides 'Yes(don't show again)' the popup is not shown.
-  get ranDryRunInCodebaseLifetime(): boolean {
-    return this._get<boolean>("ranDryRunInCodebaseLifetime") || false;
-  }
-  set ranDryRunInCodebaseLifetime(v: boolean) {
-    this._update("ranDryRunInCodebaseLifetime", v);
-  }
-
   // If the project needs a clean configure as a result
   // of an operation that alters the configure state
   // (makefile configuration change, build target change,
@@ -87,7 +75,6 @@ export class StateManager {
     this.buildTarget = undefined;
     this.launchConfiguration = undefined;
     this.ranConfigureInCodebaseLifetime = false;
-    this.ranDryRunInCodebaseLifetime = false;
     this.configureDirty = false;
 
     if (reloadWindow) {

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -422,3 +422,14 @@ function getPackageInfo(): IPackageInfo {
     aiKey: "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
   };
 }
+
+export type ConfigureOnOpenScope = "user" | "workspace";
+export function logConfigureOnOpenTelemetry(
+  configureOnOpen: boolean,
+  scope: ConfigureOnOpenScope | undefined = undefined
+) {
+  logEvent("configureOnOpenPopup", {
+    configureOnOpen: configureOnOpen.toString(),
+    scope: scope ?? "N/A",
+  });
+}


### PR DESCRIPTION
Most importantly, this removes the problematic and frustrating to users dry-run pop-up. 

When you open a workspace that has a Makefile, you will first be prompted with this pop-up. 

![image](https://github.com/microsoft/vscode-makefile-tools/assets/86264750/5f0c17e0-25c5-4b35-9fab-50e6236a2fa9)

Then, the makefile extension will start the configure process, and also give you this pop-up that will control what level we will save your choice in, either globally or only in this workspace. 
![image](https://github.com/microsoft/vscode-makefile-tools/assets/86264750/9057ac0e-75fb-4ac8-bb66-3eed7f1a11f5)

However, if you say no to the first pop-up, the configure process will not be started, and then you will be prompted with this:

![image](https://github.com/microsoft/vscode-makefile-tools/assets/86264750/f559b5b4-910c-4680-b89f-8600c8757016)

This will allow you to either globally turn off configuring on open, or only for the current workspace. 
