### PR TITLE
Fix incorrect uppercase Chinese language codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Bug Fixes:
 
 - Fix issue where simply clicking on tree item was opening launch target selection. [#588](https://github.com/microsoft/vscode-makefile-tools/issues/588)
 - Fix issue where selecting "Default" from the configuration drop down doesn't update Makefile Project Outline [#585](https://github.com/microsoft/vscode-makefile-tools/issues/585)
+- Fix issue where CHS and CHT wasn't being localized on Linux. [#609](https://github.com/microsoft/vscode-makefile-tools/issues/609)
 
 ## 0.9
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,8 +24,8 @@ const jsonc = require("jsonc-parser");
 const jsonSchemaFilesPatterns = ["*/*-schema.json"];
 
 const languages = [
-  { id: "zh-TW", folderName: "cht", transifexId: "zh-hant" },
-  { id: "zh-CN", folderName: "chs", transifexId: "zh-hans" },
+  { id: "zh-tw", folderName: "cht", transifexId: "zh-hant" },
+  { id: "zh-cn", folderName: "chs", transifexId: "zh-hans" },
   { id: "fr", folderName: "fra" },
   { id: "de", folderName: "deu" },
   { id: "it", folderName: "ita" },


### PR DESCRIPTION
We were using `zh-TW`, `zh-CN`, when we should've been using `zh-tw`, `zh-cn`. This should fix #609 