### PR TITLE
Don't append line ending to output for dry-run

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
       "runtimeExecutable": "${execPath}",
       "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
       "sourceMaps": true,
-      "outFiles": ["${workspaceFolder}/**/*.js"],
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
       "env": {
         "MAKEFILE_TOOLS_TESTING": "1",
         "WindowsSDKVersion": "12.3.45678.9\\",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Bug Fixes:
 - Fix issue where simply clicking on tree item was opening launch target selection. [#588](https://github.com/microsoft/vscode-makefile-tools/issues/588)
 - Fix issue where selecting "Default" from the configuration drop down doesn't update Makefile Project Outline [#585](https://github.com/microsoft/vscode-makefile-tools/issues/585)
 - Fix issue where CHS and CHT wasn't being localized on Linux. [#609](https://github.com/microsoft/vscode-makefile-tools/issues/609)
+- Fix issue where line endings were being added in the output which broke long compile commands from output of make.exe. [#545](https://github.com/microsoft/vscode-makefile-tools/issues/545)
 
 ## 0.9
 

--- a/src/make.ts
+++ b/src/make.ts
@@ -723,7 +723,7 @@ export async function generateParseContent(
     let heartBeat: number = Date.now();
 
     let stdout: any = (result: string): void => {
-      const appendStr: string = `${result} ${lineEnding}`;
+      const appendStr: string = `${result}`;
       completeOutput += appendStr;
       fs.appendFileSync(dryrunFile, appendStr);
 


### PR DESCRIPTION
Fixes #545 

In short, the issue is that when outputs are very long, they may get split up into different invocations of the `stdout` handler. This can break when the configure step is being run, because when we invoke `make.exe` on the Makefile, and there is a very long compilation command output, if it gets split up, we might not handle the entire compile command output. 

The issue and an example is described here: #545 

vsix here: 
[makefile-tools.zip](https://github.com/user-attachments/files/16336478/makefile-tools.zip)

