### PR TITLE
Support backtick command expansion in Linux for compile_commands.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -477,6 +477,15 @@
           },
           "scope": "resource"
         },
+        "makefile.safeCommands": {
+          "type": "array",
+          "default": [],
+          "description": "%makefile-tools.configuration.makefile.safeCommands.description%",
+          "items": {
+            "type": "string"
+          },
+          "scope": "resource"
+        },
         "makefile.configureOnOpen": {
           "type": "boolean",
           "default": null,

--- a/package.nls.json
+++ b/package.nls.json
@@ -52,6 +52,7 @@
   "makefile-tools.configuration.makefile.dryrunSwitches.description": "Arguments to pass to the dry-run make invocation",
   "makefile-tools.configuration.makefile.additionalCompilerNames.description": "Names of compiler tools to be added to the extension known list",
   "makefile-tools.configuration.makefile.excludeCompilerNames.description": "Names of compiler tools to be excluded from the extension known list",
+  "makefile-tools.configuration.makefile.safeCommands.description": "Commands that are safe to perform command substitution with",
   "makefile-tools.configuration.makefile.configureOnOpen.description": "Automatically configure Makefile project directories when they are opened",
   "makefile-tools.configuration.makefile.configureOnEdit.description": "Automatically configure Makefile project directories when any relevant makefiles and/or settings are changed",
   "makefile-tools.configuration.makefile.configureAfterCommand.description": "Automatically configure Makefile project directories after relevant operations, like change build configuration or makefile target",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -742,6 +742,27 @@ export async function readExcludeCompilerNames(): Promise<void> {
   }
 }
 
+let safeCommands: string[] | undefined;
+export function getSafeCommands(): string[] | undefined {
+  return safeCommands;
+}
+export function setSafeCommands(commands: string[]): void {
+  safeCommands = commands;
+}
+export async function readSafeCommands(): Promise<void> {
+  safeCommands = await util.getExpandedSetting<string[]>("safeCommands");
+  if (safeCommands && safeCommands.length > 0) {
+    logger.message(
+      localize(
+        "safe.commands",
+        "Safe commands: '{0}'",
+        safeCommands?.join("', '")
+      ),
+      "Debug"
+    );
+  }
+}
+
 let dryrunSwitches: string[] | undefined;
 export function getDryrunSwitches(): string[] | undefined {
   return dryrunSwitches;
@@ -1721,6 +1742,7 @@ export async function initFromSettings(
   await readDryrunSwitches();
   await readAdditionalCompilerNames();
   await readExcludeCompilerNames();
+  await readSafeCommands();
   await readMakefileConfigurations();
   await readCurrentLaunchConfiguration();
   await readDefaultLaunchConfiguration();
@@ -2109,6 +2131,14 @@ export async function initFromSettings(
         await util.getExpandedSetting<string[]>(subKey);
       if (!util.areEqual(updatedExcludeCompilerNames, excludeCompilerNames)) {
         await readExcludeCompilerNames();
+        updatedSettingsSubkeys.push(subKey);
+      }
+
+      subKey = "safeCommands";
+      let updatedSafeCommands: string[] | undefined =
+        await util.getExpandedSetting<string[]>(subKey);
+      if (!util.areEqual(updatedSafeCommands, safeCommands)) {
+        readSafeCommands();
         updatedSettingsSubkeys.push(subKey);
       }
 

--- a/src/make.ts
+++ b/src/make.ts
@@ -794,14 +794,17 @@ export async function generateParseContent(
     }, 5 * 1000);
 
     // The dry-run analysis should operate on english.
+    const opts: util.ProcOptions = {
+      workingDirectory: util.getWorkspaceRoot(),
+      forceEnglish: true,
+      ensureQuoted: true,
+      stdoutCallback: stdout,
+      stderrCallback: stderr,
+    };
     const result: util.SpawnProcessResult = await util.spawnChildProcess(
       configuration.getConfigurationMakeCommand(),
       makeArgs,
-      util.getWorkspaceRoot(),
-      true,
-      true,
-      stdout,
-      stderr
+      opts
     );
     clearInterval(timeout);
     let elapsedTime: number = util.elapsedTimeSince(startTime);
@@ -1171,14 +1174,17 @@ export async function runPrePostConfigureScript(
     };
 
     // The preconfigure invocation should use the system locale.
+    const opts: util.ProcOptions = {
+      workingDirectory: util.getWorkspaceRoot(),
+      forceEnglish: false,
+      ensureQuoted: false,
+      stdoutCallback: stdout,
+      stderrCallback: stderr,
+    };
     const result: util.SpawnProcessResult = await util.spawnChildProcess(
       runCommand,
       concreteScriptArgs,
-      util.getWorkspaceRoot(),
-      false,
-      false,
-      stdout,
-      stderr
+      opts
     );
     if (result.returnCode === ConfigureBuildReturnCodeTypes.success) {
       if (someErr) {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -442,7 +442,11 @@ async function parseLineAsTool(
     // don't use join and neither paths/filenames processed above if we want to keep the exact text in the makefile
     pathInMakefile: match[1] + match[2],
     fullPath: toolFullPath,
-    arguments: match[match.length - 1],
+    arguments: await util.replaceCommands(
+      match[match.length - 1],
+      configuration.getSafeCommands(),
+      { cwd: util.getWorkspaceRoot(), shell: true }
+    ),
     found: toolFound,
   };
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -471,6 +471,11 @@ export async function replaceCommands(
   safeCommands: string[] | undefined,
   opt: child_process.SpawnOptions
 ): Promise<string> {
+  // Early exit, backtick doesn't apply on Windows
+  if (process.platform === "win32") {
+    return x;
+  }
+
   const regex = /`([^\s]+)\s(.*?)`/g;
   let match = regex.exec(x);
   while (match !== null) {
@@ -494,6 +499,12 @@ export async function replaceCommands(
   return x;
 }
 
+/**
+ * This is only designed to run for Linux for commands taken from a backtick context.
+ * @param x command
+ * @param opt SpawnOptions
+ * @returns resulting string
+ */
 async function runCommand(
   x: string,
   opt: child_process.SpawnOptions

--- a/src/util.ts
+++ b/src/util.ts
@@ -498,6 +498,11 @@ async function runCommand(
   x: string,
   opt: child_process.SpawnOptions
 ): Promise<string> {
+  // backtick doesn't apply on Windows, return early
+  if (process.platform === "win32") {
+    return x;
+  }
+
   const child = child_process.spawn("/bin/bash", ["-c", `"${x}"`], opt);
   return new Promise<string>((resolve) => {
     let output = "";


### PR DESCRIPTION
Fixes #670 and slightly adapts an old out of date PR: #409