### PR TITLE
Automation profile include args

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -399,43 +399,79 @@ export function spawnChildProcess(
         `integrated.automationShell.${shellPlatform}`
       ); // and replaced with automationProfile
 
-    if (typeof shellType === "object") {
-      shellType = shellType["path"];
-    }
-
     // Final quoting decisions for process name and args before being executed.
     let qProcessName: string = options.ensureQuoted
       ? quoteStringIfNeeded(processName)
       : processName;
+
     let qArgs: string[] = options.ensureQuoted
       ? args.map((arg) => {
           return quoteStringIfNeeded(arg);
         })
       : args;
 
+    let lprocessname: string;
+    let largs: string[];
+    let lenv: EnvironmentVariables;
+    let lshell: string | boolean;
+    let lshell_describe: string;
+    if (typeof shellType !== "object") {
+      // no profile specified -> start process on default shell
+      lprocessname = qProcessName;
+      largs = qArgs;
+      lshell = true;
+      lshell_describe = "default";
+      lenv = finalEnvironment;
+    } else {
+      const profile_args = (shellType["args"] as string[]) ?? [];
+      const profile_env = (shellType["env"] as EnvironmentVariables) ?? {};
+
+      if (profile_args.length > 0) {
+        // automation profile with args specified, child_process.spawn dow not support
+        //  args for shell so have to start the process in the specified shell manually
+        lprocessname = shellType["path"];
+        largs = [
+          profile_args.join(" "),
+          ' -c "',
+          qProcessName + " " + qArgs.join(" ") + '"',
+        ];
+        lshell = true;
+        lshell_describe = "default";
+        lenv = { ...finalEnvironment, ...profile_env };
+      } else {
+        // start process on specified shell
+        lprocessname = qProcessName;
+        largs = qArgs;
+        lshell = shellType["path"];
+        lshell_describe = shellType["path"];
+        lenv = { ...finalEnvironment, ...profile_env };
+      }
+    }
+
     if (options.ensureQuoted) {
       logger.message(
         localize(
           "utils.quoting",
           "Spawning child process with:\n process name: {0}\n process args: {1}\n working directory: {2}\n shell type: {3}",
-          qProcessName,
-          qArgs.join(","),
+          lprocessname,
+          largs.join(","),
           options.workingDirectory,
-          shellType || "default"
+          lshell_describe
         ),
         "Debug"
       );
     }
 
     const child: child_process.ChildProcess = child_process.spawn(
-      qProcessName,
-      qArgs,
+      lprocessname,
+      largs,
       {
         cwd: options.workingDirectory,
-        shell: shellType || true,
-        env: finalEnvironment,
+        shell: lshell,
+        env: lenv,
       }
     );
+
     if (child.pid) {
       make.setCurPID(child.pid);
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -415,8 +415,13 @@ export function spawnChildProcess(
     let lenv: EnvironmentVariables;
     let lshell: string | boolean;
     let lshell_describe: string;
-    if (typeof shellType !== "object") {
+    if (
+      typeof shellType !== "object" ||
+      qProcessName.startsWith("cmd") ||
+      qProcessName.startsWith("/bin/bash")
+    ) {
       // no profile specified -> start process on default shell
+      // also not trying to execute other shell commands in the automationShell, to avoid casting issues
       lprocessname = qProcessName;
       largs = qArgs;
       lshell = true;


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-makefile-tools/issues/716

i don't usually code in typeskript so i don't know how usefull this is.
also i could only test on a windows -> msys setup.

The fix is somewhat convoluted, since child_process.spawn does not appear to support specifying shell arguments.


i also didn't let 'cmd' / '/bin/bash' commands execute via the specified shell, because escaping the caracters correctly seems impossible; this affects the call from parser.ts

the setup also only works if gcc is in PATH, but that seems to be because c_cpp extension does not use the provided shell to lookup system path from the given compiler. 
