### PR TITLE
fix name handling in launch config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Bug Fixes:
 - Fix "Makefile Tools" being translated in localized languages when it should remain as a proper noun. [#731](https://github.com/microsoft/vscode-makefile-tools/issues/731)
 - Fix binary path links in output log not being clickable on Windows when the path has no .exe extension. [#698](https://github.com/microsoft/vscode-makefile-tools/issues/698)
 - Fix `parseCompilerArgs.bat` failing when macro definitions contain numeric expressions like `-1` inside quoted values. [#755](https://github.com/microsoft/vscode-makefile-tools/issues/755)
+- Fix Project Outline showing "Unset" for launch configurations that have a `name` field. [#808](https://github.com/microsoft/vscode-makefile-tools/issues/808)
 
 ## 0.11
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -932,7 +932,7 @@ async function readCurrentLaunchConfiguration(): Promise<void> {
     );
   }
 
-  let launchConfigStr: string = "No launch configuration set.";
+  let launchConfigStr: string = "";
   if (currentLaunchConfiguration) {
     launchConfigStr = launchConfigurationDisplayName(currentLaunchConfiguration);
     logger.message(
@@ -970,7 +970,9 @@ async function readCurrentLaunchConfiguration(): Promise<void> {
     }
   }
 
-  statusBar.setLaunchConfiguration(launchConfigStr);
+  statusBar.setLaunchConfiguration(
+    launchConfigStr || localize("no.launch.configuration.set", "No launch configuration set")
+  );
   await extension._projectOutlineProvider.updateLaunchTarget(launchConfigStr);
 }
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1836,7 +1836,9 @@ export async function initFromSettings(
   await extension._projectOutlineProvider.update(
     extension.getState().buildConfiguration,
     extension.getState().buildTarget,
-    extension.getState().launchConfiguration,
+    currentLaunchConfiguration
+      ? launchConfigurationDisplayName(currentLaunchConfiguration)
+      : undefined,
     getConfigurationMakefile(),
     getConfigurationMakeCommand(),
     getConfigurationBuildLog()

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -81,7 +81,10 @@ export class LaunchTargetNode extends BaseNode {
     let shortName: string;
 
     if (!launchConfiguration) {
-      shortName = localize("Unset", "Unset");
+      // If the name doesn't match the technical cwd>binary(args) format,
+      // it may be a user-friendly display name from the "name" field in
+      // makefile.launchConfigurations. Use it as-is. If empty, show "Unset".
+      shortName = completeLaunchTargetName || localize("Unset", "Unset");
     } else {
       if (vscode.workspace.workspaceFolders) {
         // In a complete launch target string, the binary path is relative to cwd.

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -86,17 +86,20 @@ export class LaunchTargetNode extends BaseNode {
       // makefile.launchConfigurations. Use it as-is. If empty, show "Unset".
       shortName = completeLaunchTargetName || localize("Unset", "Unset");
     } else {
+      let binaryPath: string;
       if (vscode.workspace.workspaceFolders) {
         // In a complete launch target string, the binary path is relative to cwd.
         // In here, since we don't show cwd, make it relative to current workspace folder.
-        shortName = util.makeRelPath(
+        binaryPath = util.makeRelPath(
           launchConfiguration.binaryPath,
           vscode.workspace.workspaceFolders[0].uri.fsPath
         );
       } else {
         // Just in case, if for some reason we don't have a workspace folder, return full binary path.
-        shortName = launchConfiguration.binaryPath;
+        binaryPath = launchConfiguration.binaryPath;
       }
+      let binArgs: string = launchConfiguration.binaryArgs.join(",");
+      shortName = `${binaryPath}(${binArgs})`;
     }
 
     return localize(


### PR DESCRIPTION
Problem

PR #793 added name and description fields to makefile.launchConfigurations, but introduced a regression
where the Project Outline panel displays incorrect launch target information. Fixes #808.

Changes

1. Fix named configs showing "Unset" in Project Outline (tree.ts)

getShortLaunchTargetName() receives the display name (e.g., "Run with arguments") from 
launchConfigurationDisplayName(), but passes it to stringToLaunchConfiguration() which expects the
technical cwd>binary(args) format. Parsing fails and the tree unconditionally falls back to "Unset".

Fix: When stringToLaunchConfiguration() fails, use the input as-is if non-empty — it's a user-friendly
display name. Only fall back to "Unset" when the input is empty.

2. Fix display name lost on restart (configuration.ts)

After readCurrentLaunchConfiguration() correctly updates the tree with the display name, 
initFromSettings() overwrites it by passing extension.getState().launchConfiguration (the raw technical
string) to _projectOutlineProvider.update().

Fix: Pass launchConfigurationDisplayName(currentLaunchConfiguration) instead of the raw state string, so
the tree always receives the friendly name when one exists.

3. Fix unnamed configs missing args in Project Outline (tree.ts)

getShortLaunchTargetName() only showed the binary path (e.g., out.exe) for unnamed configs, dropping the
args portion entirely.

Fix: Include args in the short name so unnamed configs display as out.exe(-flag) instead of just out.exe.

4. Fix prose string leaking into tree contract (configuration.ts)

readCurrentLaunchConfiguration() passed the prose string "No launch configuration set." to 
updateLaunchTarget() when no configuration was active, leaking status-bar text into the tree.

Fix: Pass "" instead, with the status bar receiving the prose string via a separate fallback.