### PR TITLE
Fix 'succesful' typo in source comments

### DIFF
--- a/src/make.ts
+++ b/src/make.ts
@@ -1204,7 +1204,7 @@ export async function runPrePostConfigureScript(
     if (result.returnCode === ConfigureBuildReturnCodeTypes.success) {
       if (someErr) {
         // Depending how the preconfigure scripts (and any inner called sub-scripts) are written,
-        // it may happen that the final error code returned by them to be succesful even if
+        // it may happen that the final error code returned by them to be successful even if
         // previous steps reported errors.
         // Until a better error code analysis, simply warn wih a logger message and turn the successful
         // return code into ConfigureBuildReurnCodeTypes.other, which would let us know in telemetry
@@ -1345,7 +1345,7 @@ interface ConfigureSubphasesStatus {
   recursiveConfigure?: ConfigureSubphasesStatus;
 }
 
-// What makes a configure succesful or failed.
+// What makes a configure successful or failed.
 // This is not called when there was a cancellation, to simplify the logic and rules.
 // Here are some considerations:
 // 1.   If generate parse content returns a non successful return code,

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -204,7 +204,7 @@ function filterKey(key: string): string {
 // Analyze recursively all the settings for telemetry and type validation.
 // Return all the telemetry properties that have been collected throughout this recursive process.
 // If telemetryProperties is null, this function performs only type validation.
-// If analyzeSettings gets called before a configure (or after an unsuccesful one), it is possible to have
+// If analyzeSettings gets called before a configure (or after an unsuccessful one), it is possible to have
 // inaccurate or incomplete telemetry information for makefile and launch configurations.
 // This is not very critical since any of their state changes will update telemetry for them.
 export async function analyzeSettings(


### PR DESCRIPTION
Corrects three instances of the 'succesful' misspelling in source comments (two in `src/make.ts`, one as 'unsuccesful' in `src/telemetry.ts`). Comment-only change.