### PR TITLE
update windows image version in pipeline configurations

### DIFF
--- a/jobs/cg.yml
+++ b/jobs/cg.yml
@@ -35,12 +35,12 @@ extends:
   parameters:
     pool:
       name: AzurePipelines-EO
-      image: 1ESPT-Windows2022
+      image: 1ESPT-Windows2025
       os: windows
     sdl:
       sourceAnalysisPool:
         name: AzurePipelines-EO
-        image: 1ESPT-Windows2022
+        image: 1ESPT-Windows2025
         os: windows
       componentgovernance:
         ignoreDirectories: node_modules,dist,i18n

--- a/jobs/loc/TranslationsImportExport.yml
+++ b/jobs/loc/TranslationsImportExport.yml
@@ -30,12 +30,12 @@ extends:
   parameters:
     pool:
       name: AzurePipelines-EO
-      image: 1ESPT-Windows2022
+      image: 1ESPT-Windows2025
       os: windows
     sdl:
       sourceAnalysisPool:
         name: AzurePipelines-EO
-        image: 1ESPT-Windows2022
+        image: 1ESPT-Windows2025
         os: windows
     customBuildTags:
       - ES365AIMigrationTooling


### PR DESCRIPTION
This pull request updates the build pipeline configuration to use a newer Windows image version for both the main and localization jobs. The change ensures that all relevant jobs now run on `1ESPT-Windows2025` instead of the previous `1ESPT-Windows2022` image.

Build pipeline updates:

* Updated the `image` parameter from `1ESPT-Windows2022` to `1ESPT-Windows2025` in the `jobs/cg.yml` pipeline configuration for both the main pool and the `sourceAnalysisPool`.
* Updated the `image` parameter from `1ESPT-Windows2022` to `1ESPT-Windows2025` in the `jobs/loc/TranslationsImportExport.yml` pipeline configuration for both the main pool and the `sourceAnalysisPool`.