### PR TITLE
Migrate MicroBuild pipelines

### DIFF
--- a/jobs/prerelease.yml
+++ b/jobs/prerelease.yml
@@ -33,10 +33,14 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: AzurePipelines-EO
+      image: 1ESPT-Windows2025
+      os: windows
     sdl:
       sourceAnalysisPool:
-        name: VSEngSS-MicroBuild2022-1ES
+        name: AzurePipelines-EO
+        image: 1ESPT-Windows2025
+        os: windows
     customBuildTags:
       - ES365AIMigrationTooling
 

--- a/jobs/release.yml
+++ b/jobs/release.yml
@@ -53,10 +53,14 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: AzurePipelines-EO
+      image: 1ESPT-Windows2025
+      os: windows
     sdl:
       sourceAnalysisPool:
-        name: VSEngSS-MicroBuild2022-1ES
+        name: AzurePipelines-EO
+        image: 1ESPT-Windows2025
+        os: windows
     customBuildTags:
       - ES365AIMigrationTooling
     stages:

--- a/jobs/release/prerelease.yml
+++ b/jobs/release/prerelease.yml
@@ -20,7 +20,9 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: AzurePipelines-EO
+      image: 1ESPT-Windows2025
+      os: windows
 
     stages:
       - stage: release

--- a/jobs/release/release.yml
+++ b/jobs/release/release.yml
@@ -20,7 +20,9 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: AzurePipelines-EO
+      image: 1ESPT-Windows2025
+      os: windows
 
     stages:
       - stage: Validate


### PR DESCRIPTION
This pull request updates the pipeline configuration to use a new build pool and image across several YAML job files. The main goal is to migrate from the `VSEngSS-MicroBuild2022-1ES` pool to the `AzurePipelines-EO` pool with the `1ESPT-Windows2025` image, ensuring consistency and modernization of the build environment.

**Pipeline environment migration:**

* Updated the `pool` and `sdl.sourceAnalysisPool` settings in `jobs/prerelease.yml` and `jobs/release.yml` to use `AzurePipelines-EO` with the `1ESPT-Windows2025` image and `windows` OS, replacing the previous `VSEngSS-MicroBuild2022-1ES` pool. [[1]](diffhunk://#diff-e7239a2f6b9a7678d729e5a461a9b585101009f294c1e641bd5b154e16ca28a4L36-R43) [[2]](diffhunk://#diff-8181cd3f960dcc22220250509cb13b8dd9fb0ad180bd92c78c35d8cd5c127c51L56-R63)
* Updated the `pool` configuration in `jobs/release/prerelease.yml` and `jobs/release/release.yml` to use the new pool and image (`AzurePipelines-EO`, `1ESPT-Windows2025`, `windows`). [[1]](diffhunk://#diff-7b7c10c627921eaeb34e884afad4dd4b7707c9ef1ff15f9451a7af483c9b27dbL23-R25) [[2]](diffhunk://#diff-00a52e9268325fd97bdcd98dd8eeff56e4891b2a83b90d593dfe7dbc14ff3b07L23-R25)