### PR TITLE
Bump Node.js version in ADO pipeline to 22.x

### DIFF
--- a/jobs/cg.yml
+++ b/jobs/cg.yml
@@ -76,9 +76,9 @@ extends:
                 fetchTags: false
 
               - task: NodeTool@0
-                displayName: Use Node 20.x
+                displayName: Use Node 22.x
                 inputs:
-                  versionSpec: 20.x
+                  versionSpec: 22.x
 
               - task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@3
                 displayName: Use Yarn 1.x

--- a/jobs/loc/TranslationsImportExport.yml
+++ b/jobs/loc/TranslationsImportExport.yml
@@ -52,7 +52,7 @@ extends:
             steps:
               - task: NodeTool@0
                 inputs:
-                  versionSpec: "20.x"
+                  versionSpec: "22.x"
                 displayName: "Install Node.js"
 
               - task: CmdLine@2

--- a/jobs/release/prerelease.yml
+++ b/jobs/release/prerelease.yml
@@ -47,9 +47,9 @@ extends:
                 ignoreLASTEXITCODE: true
                 displayName: "Set the release name"
               - task: NodeTool@0
-                displayName: "Use Node 20.x"
+                displayName: "Use Node 22.x"
                 inputs:
-                  versionSpec: 20.x
+                  versionSpec: 22.x
               - script: npm install -g @vscode/vsce
                 displayName: "install vsce"
               - task: AzureCLI@2

--- a/jobs/release/release.yml
+++ b/jobs/release/release.yml
@@ -70,9 +70,9 @@ extends:
                   targetPath: $(Build.StagingDirectory)\vsix
             steps:
               - task: NodeTool@0
-                displayName: "Use Node 20.x"
+                displayName: "Use Node 22.x"
                 inputs:
-                  versionSpec: 20.x
+                  versionSpec: 22.x
               - script: npm install -g @vscode/vsce
                 displayName: "install vsce"
               - task: AzureCLI@2

--- a/jobs/shared/build.yml
+++ b/jobs/shared/build.yml
@@ -13,9 +13,9 @@ parameters:
 
 steps:
   - task: NodeTool@0
-    displayName: Use Node 20.x
+    displayName: Use Node 22.x
     inputs:
-      versionSpec: 20.x
+      versionSpec: 22.x
 
   - task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@3
     displayName: Use Yarn 1.x


### PR DESCRIPTION
This pull request updates the Node.js version used in all CI/CD pipeline jobs from Node 20.x to Node 22.x. This ensures that our build, release, and localization processes are using the latest LTS version of Node.js for improved performance, security, and compatibility.