### PR TITLE
enforce CFS network isolation

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,3 @@
 # [OSS Contributors] Delete this .npmrc file to use the npmjs registry instead of the Microsoft Azure Artifacts feed for local development
 
-registry=https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/                  
-always-auth=true
+registry=https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/

--- a/jobs/cg.yml
+++ b/jobs/cg.yml
@@ -66,6 +66,8 @@ extends:
         exclusionsFile: $(Build.SourcesDirectory)\jobs\policheckExclusions.xml
     customBuildTags:
       - ES365AIMigrationTooling
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
     stages:
       - stage: stage
         jobs:
@@ -75,34 +77,39 @@ extends:
               - checkout: self
                 fetchTags: false
 
-              - task: NodeTool@0
-                displayName: Use Node 22.x
+              - task: UseNode@1
+                displayName: "Use Node 22.x"
                 inputs:
-                  versionSpec: 22.x
+                  version: "22.x"
 
-              - task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@3
-                displayName: Use Yarn 1.x
+              - task: CmdLine@2
+                displayName: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
+                inputs:
+                  script: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
 
-              - task: geeklearningio.gl-vsts-tasks-yarn.yarn-task.Yarn@3
+              - task: CmdLine@2
                 displayName: Yarn install
                 inputs:
-                  arguments: install
+                  script: yarn install
+                env:
+                  npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
 
-              - script: npm install -g @vscode/vsce
-                displayName: "install vsce"
-
-              - script: yarn compile-production
-                displayName: "Compile production"
+              - task: CmdLine@2
+                displayName: Build files
+                inputs:
+                  script: |
+                    yarn compile-production
+                env:
+                  npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
 
               - task: CmdLine@2
                 displayName: Run VSCE to package vsix
                 inputs:
                   script: |-
                     echo Building VSIX
-                    vsce package --yarn -o $(Build.StagingDirectory)\makefile-tools.vsix
-
-              - script: npm uninstall -g @vscode/vsce
-                displayName: "uninstall vsce"
+                    yarn run vsce package --yarn -o $(Build.StagingDirectory)\makefile-tools.vsix
+                env:
+                  npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
 
               - task: DeleteFiles@1
                 displayName: Remove code that should not be scanned

--- a/jobs/loc/TranslationsImportExport.yml
+++ b/jobs/loc/TranslationsImportExport.yml
@@ -39,6 +39,8 @@ extends:
         os: windows
     customBuildTags:
       - ES365AIMigrationTooling
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
     stages:
       - stage: stage
         jobs:
@@ -56,8 +58,15 @@ extends:
                 displayName: "Install Node.js"
 
               - task: CmdLine@2
+                displayName: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
+                inputs:
+                  script: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
+
+              - task: CmdLine@2
                 inputs:
                   script: "yarn install"
+                env:
+                  npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
 
               - task: CmdLine@2
                 inputs:

--- a/jobs/prerelease.yml
+++ b/jobs/prerelease.yml
@@ -43,6 +43,8 @@ extends:
         os: windows
     customBuildTags:
       - ES365AIMigrationTooling
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
 
     stages:
       - stage: verify_parameters

--- a/jobs/release.yml
+++ b/jobs/release.yml
@@ -63,6 +63,8 @@ extends:
         os: windows
     customBuildTags:
       - ES365AIMigrationTooling
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
     stages:
       - stage: verify_parameters
         jobs:

--- a/jobs/release/prerelease.yml
+++ b/jobs/release/prerelease.yml
@@ -23,6 +23,8 @@ extends:
       name: AzurePipelines-EO
       image: 1ESPT-Windows2025
       os: windows
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
 
     stages:
       - stage: release
@@ -50,8 +52,14 @@ extends:
                 displayName: "Use Node 22.x"
                 inputs:
                   versionSpec: 22.x
-              - script: npm install -g @vscode/vsce
+              - task: CmdLine@2
+                displayName: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
+                inputs:
+                  script: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
+              - script: npm install -g @vscode/vsce@3.1.0
                 displayName: "install vsce"
+                env:
+                  npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
               - task: AzureCLI@2
                 displayName: "Generate AAD_TOKEN"
                 inputs:

--- a/jobs/release/release.yml
+++ b/jobs/release/release.yml
@@ -23,6 +23,8 @@ extends:
       name: AzurePipelines-EO
       image: 1ESPT-Windows2025
       os: windows
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
 
     stages:
       - stage: Validate
@@ -73,8 +75,14 @@ extends:
                 displayName: "Use Node 22.x"
                 inputs:
                   versionSpec: 22.x
-              - script: npm install -g @vscode/vsce
+              - task: CmdLine@2
+                displayName: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
+                inputs:
+                  script: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
+              - script: npm install -g @vscode/vsce@3.1.0
                 displayName: "install vsce"
+                env:
+                  npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
               - task: AzureCLI@2
                 displayName: "Generate AAD_TOKEN"
                 inputs:

--- a/jobs/shared/build.yml
+++ b/jobs/shared/build.yml
@@ -17,16 +17,10 @@ steps:
     inputs:
       versionSpec: 22.x
 
-  - task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@3
-    displayName: Use Yarn 1.x
-
   - task: CmdLine@2
     displayName: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
     inputs:
       script: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
-
-  - script: npm install -g @vscode/vsce
-    displayName: "install vsce"
 
   - task: PowerShell@2
     displayName: Set build name
@@ -66,6 +60,8 @@ steps:
     inputs:
       script: |
         yarn compile-production
+    env:
+      npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
 
   - task: MSBuild@1
     displayName: Sign files
@@ -78,13 +74,15 @@ steps:
     inputs:
       script: |
         mkdir $(Build.ArtifactStagingDirectory)\vsix
-        if "${{parameters.IsPreRelease}}"=="1" (vsce package --yarn -o $(Build.ArtifactStagingDirectory)\vsix\makefile-tools.vsix --pre-release) else (vsce package --yarn -o $(Build.ArtifactStagingDirectory)\vsix\makefile-tools.vsix)
+        if "${{parameters.IsPreRelease}}"=="1" (yarn run vsce package --yarn -o $(Build.ArtifactStagingDirectory)\vsix\makefile-tools.vsix --pre-release) else (yarn run vsce package --yarn -o $(Build.ArtifactStagingDirectory)\vsix\makefile-tools.vsix)
+    env:
+      npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
 
   - task: CmdLine@2
     displayName: Generate Extension Manifest
     inputs:
       script: |
-        vsce generate-manifest -i $(Build.ArtifactStagingDirectory)\vsix\makefile-tools.vsix -o $(Build.ArtifactStagingDirectory)\vsix\extension.manifest
+        yarn run vsce generate-manifest -i $(Build.ArtifactStagingDirectory)\vsix\makefile-tools.vsix -o $(Build.ArtifactStagingDirectory)\vsix\extension.manifest
 
   - task: CmdLine@2
     displayName: Prepare manifest for signing

--- a/package.json
+++ b/package.json
@@ -979,5 +979,6 @@
       "supported": false,
       "description": ""
     }
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
- Add networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3 to all 6 pipeline definitions (cg, prerelease, release, loc, release/release, release/prerelease).
- Remove the geeklearningio YarnInstaller@3 task from cg.yml and shared/build.yml. It downloads Yarn from publicblobs.geeklearning.io which is FORBIDDEN per SFI-ES4.2.4. The 1ESPT-Windows2025 image ships Yarn 1.22.22 pre-installed — no runtime download needed.
- Use @vscode/vsce from devDependencies via 'yarn run vsce' in pipelines that check out the repo (cg.yml, shared/build.yml), eliminating the unpinned 'npm install -g @vscode/vsce' that could resolve to a version not saved in the CFS feed.
- Pin 'npm install -g @vscode/vsce@3.1.0' with npm_config_registry env on release pipelines that do not check out the repo (release/release.yml, release/prerelease.yml). 3.1.0 is the version in yarn.lock, verified saved in the CFS feed.
- Drop always-auth=true from .npmrc — it is a no-op for anonymous CFS reads (npm 10 ignores it entirely; Yarn 1 gates Authorization behind 'if (authorization)' so empty auth is dropped).
- Add del %USERPROFILE%\.npmrc cleanup step and npm_config_registry env on all yarn/vsce steps as defense-in-depth against future image changes.
- Add packageManager: yarn@1.22.22 to package.json to match the pre-installed Yarn version on the build image.