### PR TITLE
Harden release publishing and signing restore for CFS network isolation

### DIFF
--- a/build/NuGet.config
+++ b/build/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="Engineering" value="https://pkgs.dev.azure.com/devdiv/_packaging/MicroBuildToolset/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/jobs/release/prerelease.yml
+++ b/jobs/release/prerelease.yml
@@ -56,10 +56,27 @@ extends:
                 displayName: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
                 inputs:
                   script: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
-              - script: npm install -g @vscode/vsce@3.1.0
-                displayName: "install vsce"
+              - script: npm install -g @vscode/vsce@3.9.1 --include=optional --ignore-scripts=false --force
+                displayName: "Install vsce"
                 env:
                   npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
+              - script: npm rebuild -g @vscode/vsce-sign --ignore-scripts=false
+                displayName: "Rebuild vsce-sign native binary"
+                env:
+                  npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
+              - powershell: |
+                  $root = npm root -g
+                  if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($root)) { Write-Host "##vso[task.logissue type=error]npm root -g failed"; exit 1 }
+                  $root = $root.Trim()
+                  # Resolve the vsce-sign native binary exactly as `vsce publish` does: from @vscode/vsce's own module tree.
+                  # In a global install, @vscode/vsce-sign is nested under @vscode/vsce/node_modules (not hoisted to the
+                  # global root), so a top-level path check is wrong. This mirrors Node resolution and is layout-agnostic.
+                  $sign = node -e "const p=require('path'),fs=require('fs');const vsce=require.resolve('@vscode/vsce',{paths:[process.argv[1]]});const pkg=require.resolve('@vscode/vsce-sign/package.json',{paths:[p.dirname(vsce)]});const cmd=process.platform==='win32'?'vsce-sign.exe':'vsce-sign';const b=p.join(p.dirname(pkg),'bin',cmd);if(!fs.existsSync(b)){process.exit(2);}process.stdout.write(b);" "$root"
+                  if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($sign)) { Write-Host "##vso[task.logissue type=error]vsce-sign binary not resolvable from @vscode/vsce under $root"; exit 1 }
+                  Write-Host "Found vsce-sign at $($sign.Trim())"
+                  vsce --version
+                  if ($LASTEXITCODE -ne 0) { Write-Host "##vso[task.logissue type=error]vsce failed to run"; exit 1 }
+                displayName: "Verify vsce"
               - task: AzureCLI@2
                 displayName: "Generate AAD_TOKEN"
                 inputs:

--- a/jobs/release/release.yml
+++ b/jobs/release/release.yml
@@ -79,10 +79,27 @@ extends:
                 displayName: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
                 inputs:
                   script: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
-              - script: npm install -g @vscode/vsce@3.1.0
-                displayName: "install vsce"
+              - script: npm install -g @vscode/vsce@3.9.1 --include=optional --ignore-scripts=false --force
+                displayName: "Install vsce"
                 env:
                   npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
+              - script: npm rebuild -g @vscode/vsce-sign --ignore-scripts=false
+                displayName: "Rebuild vsce-sign native binary"
+                env:
+                  npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
+              - powershell: |
+                  $root = npm root -g
+                  if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($root)) { Write-Host "##vso[task.logissue type=error]npm root -g failed"; exit 1 }
+                  $root = $root.Trim()
+                  # Resolve the vsce-sign native binary exactly as `vsce publish` does: from @vscode/vsce's own module tree.
+                  # In a global install, @vscode/vsce-sign is nested under @vscode/vsce/node_modules (not hoisted to the
+                  # global root), so a top-level path check is wrong. This mirrors Node resolution and is layout-agnostic.
+                  $sign = node -e "const p=require('path'),fs=require('fs');const vsce=require.resolve('@vscode/vsce',{paths:[process.argv[1]]});const pkg=require.resolve('@vscode/vsce-sign/package.json',{paths:[p.dirname(vsce)]});const cmd=process.platform==='win32'?'vsce-sign.exe':'vsce-sign';const b=p.join(p.dirname(pkg),'bin',cmd);if(!fs.existsSync(b)){process.exit(2);}process.stdout.write(b);" "$root"
+                  if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($sign)) { Write-Host "##vso[task.logissue type=error]vsce-sign binary not resolvable from @vscode/vsce under $root"; exit 1 }
+                  Write-Host "Found vsce-sign at $($sign.Trim())"
+                  vsce --version
+                  if ($LASTEXITCODE -ne 0) { Write-Host "##vso[task.logissue type=error]vsce failed to run"; exit 1 }
+                displayName: "Verify vsce"
               - task: AzureCLI@2
                 displayName: "Generate AAD_TOKEN"
                 inputs:

--- a/jobs/shared/build.yml
+++ b/jobs/shared/build.yml
@@ -52,7 +52,7 @@ steps:
 
   - template: /jobs/shared/install-nuget.yml@self
 
-  - script: nuget restore $(Build.SourcesDirectory)\build\SignFiles.proj -PackagesDirectory $(Build.SourcesDirectory)\build\packages
+  - script: nuget restore $(Build.SourcesDirectory)\build\SignFiles.proj -PackagesDirectory $(Build.SourcesDirectory)\build\packages -ConfigFile $(Build.SourcesDirectory)\build\NuGet.config
     displayName: Restore MicroBuild Core
 
   - task: CmdLine@2


### PR DESCRIPTION
This pull request updates the build and release pipelines to improve the handling of NuGet and npm dependencies, particularly for the VSCE (Visual Studio Code Extension) publishing tool and its native signing binary. The changes ensure more reliable dependency resolution and signing during the build and release process.

Dependency management improvements:

* Added a new `NuGet.config` file in the `build` directory to specify a custom package source for NuGet restores, improving reliability and control over package resolution.
* Updated the NuGet restore step in `jobs/shared/build.yml` to explicitly use the new `NuGet.config`, ensuring the correct configuration is applied during package restoration.

VSCE toolchain and signing reliability:

* Upgraded the global installation of `@vscode/vsce` from version 3.1.0 to 3.9.1 and added additional npm flags for more robust installation in both `jobs/release/prerelease.yml` and `jobs/release/release.yml`. [[1]](diffhunk://#diff-7b7c10c627921eaeb34e884afad4dd4b7707c9ef1ff15f9451a7af483c9b27dbL59-R79) [[2]](diffhunk://#diff-00a52e9268325fd97bdcd98dd8eeff56e4891b2a83b90d593dfe7dbc14ff3b07L82-R102)
* Added steps to rebuild the `@vscode/vsce-sign` native binary globally and verify its correct resolution and functionality using a PowerShell script. This ensures the signing tool is properly available and matches how `vsce publish` expects it, reducing the risk of signing failures. [[1]](diffhunk://#diff-7b7c10c627921eaeb34e884afad4dd4b7707c9ef1ff15f9451a7af483c9b27dbL59-R79) [[2]](diffhunk://#diff-00a52e9268325fd97bdcd98dd8eeff56e4891b2a83b90d593dfe7dbc14ff3b07L82-R102)